### PR TITLE
在微信支付服务接口中，增加获取微信支付通用媒体服务的方法

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/WxPayService.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/WxPayService.java
@@ -143,6 +143,12 @@ public interface WxPayService {
   EcommerceService getEcommerceService();
 
   /**
+   * 微信支付通用媒体服务类
+   * @return
+   */
+  MerchantMediaService getMerchantMediaService();
+
+  /**
    * 设置企业付款服务类，允许开发者自定义实现类.
    *
    * @param entPayService the ent pay service

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
@@ -64,6 +64,7 @@ public abstract class BaseWxPayServiceImpl implements WxPayService {
   private RedpackService redpackService = new RedpackServiceImpl(this);
   private PayScoreService payScoreService = new PayScoreServiceImpl(this);
   private EcommerceService ecommerceService = new EcommerceServiceImpl(this);
+  private MerchantMediaService merchantMediaService =new MerchantMediaServiceImpl(this);
 
   /**
    * The Config.
@@ -93,6 +94,11 @@ public abstract class BaseWxPayServiceImpl implements WxPayService {
   @Override
   public EcommerceService getEcommerceService() {
     return ecommerceService;
+  }
+
+  @Override
+  public MerchantMediaService getMerchantMediaService() {
+    return merchantMediaService;
   }
 
   @Override


### PR DESCRIPTION
微信支付服务接口WxPayService中，遗漏了获取微信支付通用媒体服务的方法。实际使用中需要new MerchantMediaServiceImpl非常不方便。