### PR TITLE
企业微信获取应用详情时部门ID列表应该为Long类型

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpAgent.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpAgent.java
@@ -95,7 +95,7 @@ public class WxCpAgent implements Serializable {
   @Data
   public class Parties {
     @SerializedName("partyid")
-    private List<Integer> partyIds = null;
+    private List<Long> partyIds = null;
   }
 
   @Data


### PR DESCRIPTION
获取应用详情时应用可见范围的部门ID应该为Long类型