### PR TITLE
weixin-java-pay remove dependency: joda-time

### DIFF
--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/WxMpKefuServiceImplTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/WxMpKefuServiceImplTest.java
@@ -1,9 +1,10 @@
 package me.chanjar.weixin.mp.api.impl;
 
 import java.io.File;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
-import org.joda.time.DateTime;
 import org.testng.annotations.*;
 
 import com.google.inject.Inject;
@@ -169,8 +170,11 @@ public class WxMpKefuServiceImplTest {
 
   @Test
   public void testKfMsgList() throws WxErrorException {
-    Date startTime = DateTime.now().minusDays(1).toDate();
-    Date endTime = DateTime.now().minusDays(0).toDate();
+    // Date startTime = DateTime.now().minusDays(1).toDate();
+    // Date endTime = DateTime.now().minusDays(0).toDate();
+    Date startTime = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+    Date endTime = Date.from(Instant.now());
+
     WxMpKfMsgList result = this.wxService.getKefuService().kfMsgList(startTime, endTime, 1L, 50);
     assertThat(result).isNotNull();
     System.err.println(result);
@@ -178,8 +182,11 @@ public class WxMpKefuServiceImplTest {
 
   @Test
   public void testKfMsgListAll() throws WxErrorException {
-    Date startTime = DateTime.now().minusDays(1).toDate();
-    Date endTime = DateTime.now().minusDays(0).toDate();
+    // Date startTime = DateTime.now().minusDays(1).toDate();
+    // Date endTime = DateTime.now().minusDays(0).toDate();
+    Date startTime = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+    Date endTime = Date.from(Instant.now());
+
     WxMpKfMsgList result = this.wxService.getKefuService().kfMsgList(startTime, endTime);
     assertThat(result).isNotNull();
     System.err.println(result);

--- a/weixin-java-pay/pom.xml
+++ b/weixin-java-pay/pom.xml
@@ -73,11 +73,6 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/v3/auth/AutoUpdateCertificatesVerifier.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/v3/auth/AutoUpdateCertificatesVerifier.java
@@ -16,8 +16,8 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.joda.time.Instant;
-import org.joda.time.Minutes;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -110,7 +110,7 @@ public class AutoUpdateCertificatesVerifier implements Verifier {
    * 检查证书是否在有效期内，如果不在有效期内则进行更新
    */
   private void checkAndAutoUpdateCert() {
-    if (instant == null || Minutes.minutesBetween(instant, Instant.now()).getMinutes() >= minutesInterval) {
+    if (instant == null || instant.plus(minutesInterval, ChronoUnit.MINUTES).compareTo(Instant.now()) >= 0) {
       if (lock.tryLock()) {
         try {
           autoUpdateCert();


### PR DESCRIPTION
weixin-java-pay 移除依赖: joda-time; 改用 java.time api.
一共修改两处代码:
#1 weixin-java-pay 项目
1). AutoUpdateCertificatesVerifier 移除 joda-time 相关类型, 改用 java.time;
2). pom.xml 移除 joda-time 依赖;

#2 weixin-java-mp 项目
1). WxMpKefuServiceImplTest 单元测试 移除 joda-time 相关类型, 改用 java.time;