### PR TITLE
删除长连接转换短链接代码

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpQrcodeService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpQrcodeService.java
@@ -79,19 +79,6 @@ public interface WxMpQrcodeService {
 
   /**
    * <pre>
-   * 换取二维码图片url地址（可以选择是否生成压缩的网址）
-   * 详情请见: <a href="https://mp.weixin.qq.com/wiki?action=doc&id=mp1443433542&t=0.9274944716856435">生成带参数的二维码</a>
-   * </pre>
-   *
-   * @param ticket       二维码ticket
-   * @param needShortUrl 是否需要压缩的二维码地址
-   * @return the string
-   * @throws WxErrorException the wx error exception
-   */
-  String qrCodePictureUrl(String ticket, boolean needShortUrl) throws WxErrorException;
-
-  /**
-   * <pre>
    * 换取二维码图片url地址
    * 详情请见: <a href="https://mp.weixin.qq.com/wiki?action=doc&id=mp1443433542&t=0.9274944716856435">生成带参数的二维码</a>
    * </pre>

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpService.java
@@ -127,18 +127,6 @@ public interface WxMpService extends WxService {
 
   /**
    * <pre>
-   * 长链接转短链接接口.
-   * 详情请见: http://mp.weixin.qq.com/wiki/index.php?title=长链接转短链接接口
-   * </pre>
-   *
-   * @param longUrl 长url
-   * @return 生成的短地址 string
-   * @throws WxErrorException .
-   */
-  String shortUrl(String longUrl) throws WxErrorException;
-
-  /**
-   * <pre>
    * 语义查询接口.
    * 详情请见：http://mp.weixin.qq.com/wiki/index.php?title=语义理解
    * </pre>

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
@@ -209,20 +209,6 @@ public abstract class BaseWxMpServiceImpl<H, P> implements WxMpService, RequestH
   }
 
   @Override
-  public String shortUrl(String longUrl) throws WxErrorException {
-    if (longUrl.contains("&access_token=")) {
-      throw new WxErrorException("要转换的网址中存在非法字符｛&access_token=｝，" +
-        "会导致微信接口报错，属于微信bug，请调整地址，否则不建议使用此方法！");
-    }
-
-    JsonObject o = new JsonObject();
-    o.addProperty("action", "long2short");
-    o.addProperty("long_url", longUrl);
-    String responseContent = this.post(SHORTURL_API_URL, o.toString());
-    return GsonParser.parse(responseContent).get("short_url").getAsString();
-  }
-
-  @Override
   public WxMpSemanticQueryResult semanticQuery(WxMpSemanticQuery semanticQuery) throws WxErrorException {
     String responseContent = this.post(SEMANTIC_SEMPROXY_SEARCH_URL, semanticQuery.toJson());
     return WxMpSemanticQueryResult.fromJson(responseContent);

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpQrcodeServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpQrcodeServiceImpl.java
@@ -100,23 +100,13 @@ public class WxMpQrcodeServiceImpl implements WxMpQrcodeService {
   }
 
   @Override
-  public String qrCodePictureUrl(String ticket, boolean needShortUrl) throws WxErrorException {
+  public String qrCodePictureUrl(String ticket) throws WxErrorException {
     try {
-      String resultUrl = String.format(SHOW_QRCODE_WITH_TICKET.getUrl(this.wxMpService.getWxMpConfigStorage()),
+      return String.format(SHOW_QRCODE_WITH_TICKET.getUrl(this.wxMpService.getWxMpConfigStorage()),
         URLEncoder.encode(ticket, StandardCharsets.UTF_8.name()));
-      if (needShortUrl) {
-        return this.wxMpService.shortUrl(resultUrl);
-      }
-
-      return resultUrl;
     } catch (UnsupportedEncodingException e) {
       throw new WxErrorException(e.getMessage());
     }
-  }
-
-  @Override
-  public String qrCodePictureUrl(String ticket) throws WxErrorException {
-    return this.qrCodePictureUrl(ticket, false);
   }
 
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/enums/WxMpApiUrl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/enums/WxMpApiUrl.java
@@ -131,10 +131,6 @@ public interface WxMpApiUrl {
      */
     GET_TICKET_URL(API_DEFAULT_HOST_URL, "/cgi-bin/ticket/getticket?type="),
     /**
-     * 长链接转短链接接口.
-     */
-    SHORTURL_API_URL(API_DEFAULT_HOST_URL, "/cgi-bin/shorturl"),
-    /**
      * 语义查询接口.
      */
     SEMANTIC_SEMPROXY_SEARCH_URL(API_DEFAULT_HOST_URL, "/semantic/semproxy/search"),

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImplTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImplTest.java
@@ -66,17 +66,6 @@ public class BaseWxMpServiceImplTest {
     Assert.assertNotEquals(ipArray.length, 0);
   }
 
-  public void testShortUrl() throws WxErrorException {
-    String shortUrl = this.wxService.shortUrl("http://www.baidu.com/test?access_token=123");
-    assertThat(shortUrl).isNotEmpty();
-    System.out.println(shortUrl);
-  }
-
-  @Test(expectedExceptions = WxErrorException.class)
-  public void testShortUrl_with_exceptional_url() throws WxErrorException {
-    this.wxService.shortUrl("http://www.baidu.com/test?redirect_count=1&access_token=123");
-  }
-
   @Test
   public void refreshAccessTokenDuplicatelyTest() throws InterruptedException {
     // 测试多线程刷新accessToken时是否重复刷新

--- a/weixin-java-qidian/src/main/java/me/chanjar/weixin/qidian/api/WxQidianService.java
+++ b/weixin-java-qidian/src/main/java/me/chanjar/weixin/qidian/api/WxQidianService.java
@@ -122,18 +122,6 @@ public interface WxQidianService extends WxService {
 
   /**
    * <pre>
-   * 长链接转短链接接口.
-   * 详情请见: http://mp.weixin.qq.com/wiki/index.php?title=长链接转短链接接口
-   * </pre>
-   *
-   * @param longUrl 长url
-   * @return 生成的短地址 string
-   * @throws WxErrorException .
-   */
-  String shortUrl(String longUrl) throws WxErrorException;
-
-  /**
-   * <pre>
    * 构造第三方使用网站应用授权登录的url.
    * 详情请见: <a href=
   "https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316505&token=&lang=zh_CN">网站应用微信登录开发指南</a>

--- a/weixin-java-qidian/src/main/java/me/chanjar/weixin/qidian/api/impl/BaseWxQidianServiceImpl.java
+++ b/weixin-java-qidian/src/main/java/me/chanjar/weixin/qidian/api/impl/BaseWxQidianServiceImpl.java
@@ -2,11 +2,9 @@ package me.chanjar.weixin.qidian.api.impl;
 
 import static me.chanjar.weixin.qidian.enums.WxQidianApiUrl.Other.CLEAR_QUOTA_URL;
 import static me.chanjar.weixin.qidian.enums.WxQidianApiUrl.Other.GET_CALLBACK_IP_URL;
-import static me.chanjar.weixin.qidian.enums.WxQidianApiUrl.Other.GET_CURRENT_AUTOREPLY_INFO_URL;
 import static me.chanjar.weixin.qidian.enums.WxQidianApiUrl.Other.GET_TICKET_URL;
 import static me.chanjar.weixin.qidian.enums.WxQidianApiUrl.Other.NETCHECK_URL;
 import static me.chanjar.weixin.qidian.enums.WxQidianApiUrl.Other.QRCONNECT_URL;
-import static me.chanjar.weixin.qidian.enums.WxQidianApiUrl.Other.SHORTURL_API_URL;
 
 import java.io.IOException;
 import java.util.Map;
@@ -136,19 +134,6 @@ public abstract class BaseWxQidianServiceImpl<H, P> implements WxQidianService, 
   @Override
   public String getAccessToken() throws WxErrorException {
     return getAccessToken(false);
-  }
-
-  @Override
-  public String shortUrl(String longUrl) throws WxErrorException {
-    if (longUrl.contains("&access_token=")) {
-      throw new WxErrorException("要转换的网址中存在非法字符｛&access_token=｝，" + "会导致微信接口报错，属于微信bug，请调整地址，否则不建议使用此方法！");
-    }
-
-    JsonObject o = new JsonObject();
-    o.addProperty("action", "long2short");
-    o.addProperty("long_url", longUrl);
-    String responseContent = this.post(SHORTURL_API_URL, o.toString());
-    return GsonParser.parse(responseContent).get("short_url").getAsString();
   }
 
   @Override

--- a/weixin-java-qidian/src/main/java/me/chanjar/weixin/qidian/enums/WxQidianApiUrl.java
+++ b/weixin-java-qidian/src/main/java/me/chanjar/weixin/qidian/enums/WxQidianApiUrl.java
@@ -88,10 +88,6 @@ public interface WxQidianApiUrl {
      */
     GET_TICKET_URL(API_DEFAULT_HOST_URL, "/cgi-bin/ticket/getticket?type="),
     /**
-     * 长链接转短链接接口.
-     */
-    SHORTURL_API_URL(API_DEFAULT_HOST_URL, "/cgi-bin/shorturl"),
-    /**
      * 语义查询接口.
      */
     SEMANTIC_SEMPROXY_SEARCH_URL(API_DEFAULT_HOST_URL, "/semantic/semproxy/search"),

--- a/weixin-java-qidian/src/test/java/me/chanjar/weixin/qidian/api/impl/BaseWxQidianServiceImplTest.java
+++ b/weixin-java-qidian/src/test/java/me/chanjar/weixin/qidian/api/impl/BaseWxQidianServiceImplTest.java
@@ -66,17 +66,6 @@ public class BaseWxQidianServiceImplTest {
     Assert.assertNotEquals(ipArray.length, 0);
   }
 
-  public void testShortUrl() throws WxErrorException {
-    String shortUrl = this.wxService.shortUrl("http://www.baidu.com/test?access_token=123");
-    assertThat(shortUrl).isNotEmpty();
-    System.out.println(shortUrl);
-  }
-
-  @Test(expectedExceptions = WxErrorException.class)
-  public void testShortUrl_with_exceptional_url() throws WxErrorException {
-    this.wxService.shortUrl("http://www.baidu.com/test?redirect_count=1&access_token=123");
-  }
-
   @Test
   public void refreshAccessTokenDuplicatelyTest() throws InterruptedException {
     // 测试多线程刷新accessToken时是否重复刷新


### PR DESCRIPTION
关于长链转短链接口停止生成短链的公告

长链转短链服务致力于优化用户体验，在微信中提升扫码速度和成功率，解决开发者原链接（商品、支付二维码等）太长导致微信扫码速度和成功率下降的问题。但随着技术的发展，微信扫码能力已有较大提升，不再需要对原始链接进行转换。

平台将对2021年3月15日之后停止该接口新生成的短链的能力，已生成的短链暂不受影响（预计下半年停止历史生成短链接解析服务），希望开发者尽快调整相关业务逻辑，共创微信绿色、健康的生态环境。

详情 https://developers.weixin.qq.com/community/develop/doc/0000eaea400a802528dbe5f9251401