### PR TITLE
修正企业微信网页授权获取用户信息(非企业用户)时,字段缺失external_userid

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOAuth2ServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOAuth2ServiceImpl.java
@@ -76,6 +76,7 @@ public class WxCpOAuth2ServiceImpl implements WxCpOAuth2Service {
       .openId(GsonHelper.getString(jo, "OpenId"))
       .userTicket(GsonHelper.getString(jo, "user_ticket"))
       .expiresIn(GsonHelper.getString(jo, "expires_in"))
+      .externalUserid(GsonHelper.getString(jo, "external_userid"))
       .build();
   }
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpOauth2UserInfo.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpOauth2UserInfo.java
@@ -25,4 +25,5 @@ public class WxCpOauth2UserInfo {
   private String userId;
   private String userTicket;
   private String expiresIn;
+  private String externalUserid;
 }


### PR DESCRIPTION
修正企业微信网页授权获取用户信息(非企业用户)时,字段缺失external_userid
![image](https://user-images.githubusercontent.com/81662613/113084562-c9efcc80-9210-11eb-8cad-ba899a96ceed.png)
