### PR TITLE
【企业微信】WxCpXmlMessage客户联系回调字段补充

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpXmlMessage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpXmlMessage.java
@@ -317,9 +317,11 @@ public class WxCpXmlMessage implements Serializable {
 
   /**
    * 部门Id.
+   * 或者客户联系回调标签/标签组id
    */
   @XStreamAlias("Id")
-  private Long id;
+  @XStreamConverter(XStreamCDataConverter.class)
+  private String id;
 
   /**
    * 父部门id.
@@ -369,6 +371,20 @@ public class WxCpXmlMessage implements Serializable {
   @XStreamAlias("DelPartyItems")
   @XStreamConverter(value = XStreamCDataConverter.class)
   private String delPartyItems;
+
+  /**
+   * 客户联系回调: 客户接替失败的原因
+   */
+  @XStreamAlias("FailReason")
+  @XStreamConverter(XStreamCDataConverter.class)
+  private String failReason;
+
+  /**
+   * 客户联系回调: 标签类型
+   */
+  @XStreamAlias("TagType")
+  @XStreamConverter(XStreamCDataConverter.class)
+  private String tagType;
 
 
   ///////////////////////////////////////


### PR DESCRIPTION
新增字段failReason,tagType;id字段从Long改为String
![image](https://user-images.githubusercontent.com/43667559/114809151-3c99a400-9ddc-11eb-84b5-be42868ccc28.png)
![image](https://user-images.githubusercontent.com/43667559/114809188-4d4a1a00-9ddc-11eb-92f3-208a694390a5.png)
