### PR TITLE
优化使用 wx-java-open-spring-boot-starter 注册 ConfigStorage 方式

### DIFF
--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/WxOpenAutoConfiguration.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/WxOpenAutoConfiguration.java
@@ -12,6 +12,9 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @EnableConfigurationProperties(WxOpenProperties.class)
-@Import({WxOpenStorageAutoConfiguration.class, WxOpenServiceAutoConfiguration.class})
+@Import({
+  WxOpenStorageAutoConfiguration.class,
+  WxOpenServiceAutoConfiguration.class
+})
 public class WxOpenAutoConfiguration {
 }

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/WxOpenServiceAutoConfiguration.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/WxOpenServiceAutoConfiguration.java
@@ -5,6 +5,7 @@ import me.chanjar.weixin.open.api.WxOpenConfigStorage;
 import me.chanjar.weixin.open.api.WxOpenService;
 import me.chanjar.weixin.open.api.impl.WxOpenMessageRouter;
 import me.chanjar.weixin.open.api.impl.WxOpenServiceImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,9 +20,10 @@ public class WxOpenServiceAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public WxOpenService wxOpenService(WxOpenConfigStorage configStorage) {
+  @ConditionalOnBean(WxOpenConfigStorage.class)
+  public WxOpenService wxOpenService(WxOpenConfigStorage wxOpenConfigStorage) {
     WxOpenService wxOpenService = new WxOpenServiceImpl();
-    wxOpenService.setWxOpenConfigStorage(configStorage);
+    wxOpenService.setWxOpenConfigStorage(wxOpenConfigStorage);
     return wxOpenService;
   }
 
@@ -34,6 +36,4 @@ public class WxOpenServiceAutoConfiguration {
   public WxOpenComponentService wxOpenComponentService(WxOpenService wxOpenService) {
     return wxOpenService.getWxOpenComponentService();
   }
-
-
 }

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/WxOpenStorageAutoConfiguration.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/WxOpenStorageAutoConfiguration.java
@@ -1,27 +1,11 @@
 package com.binarywang.spring.starter.wxjava.open.config;
 
-import com.binarywang.spring.starter.wxjava.open.properties.RedisProperties;
-import com.binarywang.spring.starter.wxjava.open.properties.WxOpenProperties;
-import lombok.RequiredArgsConstructor;
-import me.chanjar.weixin.common.redis.JedisWxRedisOps;
-import me.chanjar.weixin.common.redis.RedisTemplateWxRedisOps;
-import me.chanjar.weixin.common.redis.RedissonWxRedisOps;
-import me.chanjar.weixin.common.redis.WxRedisOps;
-import me.chanjar.weixin.open.api.WxOpenConfigStorage;
-import me.chanjar.weixin.open.api.impl.WxOpenInMemoryConfigStorage;
-import me.chanjar.weixin.open.api.impl.WxOpenInRedisConfigStorage;
-import org.apache.commons.lang3.StringUtils;
-import org.redisson.Redisson;
-import org.redisson.api.RedissonClient;
-import org.redisson.config.Config;
-import org.redisson.config.TransportMode;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
+import com.binarywang.spring.starter.wxjava.open.config.storage.WxOpenInMemoryConfigStorageConfiguration;
+import com.binarywang.spring.starter.wxjava.open.config.storage.WxOpenInRedisConfigStorageConfiguration;
+import com.binarywang.spring.starter.wxjava.open.config.storage.WxOpenInRedisTemplateConfigStorageConfiguration;
+import com.binarywang.spring.starter.wxjava.open.config.storage.WxOpenInRedissonConfigStorageConfiguration;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.JedisPoolConfig;
+import org.springframework.context.annotation.Import;
 
 /**
  * 微信公众号存储策略自动配置.
@@ -29,113 +13,11 @@ import redis.clients.jedis.JedisPoolConfig;
  * @author someone
  */
 @Configuration
-@RequiredArgsConstructor
+@Import({
+  WxOpenInMemoryConfigStorageConfiguration.class,
+  WxOpenInRedisTemplateConfigStorageConfiguration.class,
+  WxOpenInRedisConfigStorageConfiguration.class,
+  WxOpenInRedissonConfigStorageConfiguration.class
+})
 public class WxOpenStorageAutoConfiguration {
-  private final WxOpenProperties properties;
-  private final ApplicationContext applicationContext;
-
-  @Bean
-  @ConditionalOnMissingBean(WxOpenConfigStorage.class)
-  public WxOpenConfigStorage wxOpenConfigStorage() {
-    WxOpenProperties.ConfigStorage storage = properties.getConfigStorage();
-    WxOpenProperties.StorageType type = storage.getType();
-
-    WxOpenInMemoryConfigStorage config;
-    if (type == WxOpenProperties.StorageType.redis || type == WxOpenProperties.StorageType.jedis) {
-      config = getWxOpenInRedisConfigStorage();
-    } else if (type == WxOpenProperties.StorageType.redisson) {
-      config = getWxOpenInRedissonConfigStorage();
-    } else if (type == WxOpenProperties.StorageType.redistemplate) {
-      config = getWxOpenInRedisTemplateConfigStorage();
-    } else {
-      config = getWxOpenInMemoryConfigStorage();
-    }
-
-    WxOpenProperties.ConfigStorage configStorageProperties = properties.getConfigStorage();
-    config.setWxOpenInfo(properties.getAppId(), properties.getSecret(), properties.getToken(), properties.getAesKey());
-    config.setHttpProxyHost(configStorageProperties.getHttpProxyHost());
-    config.setHttpProxyUsername(configStorageProperties.getHttpProxyUsername());
-    config.setHttpProxyPassword(configStorageProperties.getHttpProxyPassword());
-    if (configStorageProperties.getHttpProxyPort() != null) {
-      config.setHttpProxyPort(configStorageProperties.getHttpProxyPort());
-    }
-    return config;
-  }
-
-  private WxOpenInMemoryConfigStorage getWxOpenInMemoryConfigStorage() {
-    WxOpenInMemoryConfigStorage config = new WxOpenInMemoryConfigStorage();
-    return config;
-  }
-
-  private WxOpenInRedisConfigStorage getWxOpenInRedisConfigStorage() {
-    RedisProperties redisProperties = properties.getConfigStorage().getRedis();
-    JedisPool jedisPool;
-    if (redisProperties != null && StringUtils.isNotEmpty(redisProperties.getHost())) {
-      jedisPool = getJedisPool();
-    } else {
-      jedisPool = applicationContext.getBean(JedisPool.class);
-    }
-    WxRedisOps redisOps = new JedisWxRedisOps(jedisPool);
-    WxOpenInRedisConfigStorage config = new WxOpenInRedisConfigStorage(redisOps, properties.getConfigStorage().getKeyPrefix());
-    return config;
-  }
-
-  private WxOpenInRedisConfigStorage getWxOpenInRedissonConfigStorage() {
-    RedisProperties redisProperties = properties.getConfigStorage().getRedis();
-    RedissonClient redissonClient;
-    if (redisProperties != null && StringUtils.isNotEmpty(redisProperties.getHost())) {
-      redissonClient = getRedissonClient();
-    } else {
-      redissonClient = applicationContext.getBean(RedissonClient.class);
-    }
-    WxRedisOps redisOps = new RedissonWxRedisOps(redissonClient);
-    WxOpenInRedisConfigStorage config = new WxOpenInRedisConfigStorage(redisOps, properties.getConfigStorage().getKeyPrefix());
-    return config;
-  }
-
-  private WxOpenInRedisConfigStorage getWxOpenInRedisTemplateConfigStorage() {
-    StringRedisTemplate redisTemplate = applicationContext.getBean(StringRedisTemplate.class);
-    WxRedisOps redisOps = new RedisTemplateWxRedisOps(redisTemplate);
-    WxOpenInRedisConfigStorage config = new WxOpenInRedisConfigStorage(redisOps, properties.getConfigStorage().getKeyPrefix());
-    return config;
-  }
-
-
-  private JedisPool getJedisPool() {
-    WxOpenProperties.ConfigStorage storage = properties.getConfigStorage();
-    RedisProperties redis = storage.getRedis();
-
-    JedisPoolConfig config = new JedisPoolConfig();
-    if (redis.getMaxActive() != null) {
-      config.setMaxTotal(redis.getMaxActive());
-    }
-    if (redis.getMaxIdle() != null) {
-      config.setMaxIdle(redis.getMaxIdle());
-    }
-    if (redis.getMaxWaitMillis() != null) {
-      config.setMaxWaitMillis(redis.getMaxWaitMillis());
-    }
-    if (redis.getMinIdle() != null) {
-      config.setMinIdle(redis.getMinIdle());
-    }
-    config.setTestOnBorrow(true);
-    config.setTestWhileIdle(true);
-
-    JedisPool pool = new JedisPool(config, redis.getHost(), redis.getPort(),
-      redis.getTimeout(), redis.getPassword(), redis.getDatabase());
-    return pool;
-  }
-
-  private RedissonClient getRedissonClient() {
-    WxOpenProperties.ConfigStorage storage = properties.getConfigStorage();
-    RedisProperties redis = storage.getRedis();
-
-    Config config = new Config();
-    config.useSingleServer()
-      .setAddress("redis://" + redis.getHost() + ":" + redis.getPort())
-      .setDatabase(redis.getDatabase())
-      .setPassword(redis.getPassword());
-    config.setTransportMode(TransportMode.NIO);
-    return Redisson.create(config);
-  }
 }

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/WxOpenInMemoryConfigStorageConfiguration.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/WxOpenInMemoryConfigStorageConfiguration.java
@@ -1,0 +1,39 @@
+package com.binarywang.spring.starter.wxjava.open.config.storage;
+
+import com.binarywang.spring.starter.wxjava.open.properties.WxOpenProperties;
+import lombok.RequiredArgsConstructor;
+import me.chanjar.weixin.open.api.WxOpenConfigStorage;
+import me.chanjar.weixin.open.api.impl.WxOpenInMemoryConfigStorage;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author yl
+ */
+@Configuration
+@ConditionalOnProperty(
+  prefix = WxOpenProperties.PREFIX + ".config-storage", name = "type",
+  matchIfMissing = true, havingValue = "memory"
+)
+@RequiredArgsConstructor
+public class WxOpenInMemoryConfigStorageConfiguration {
+  private final WxOpenProperties properties;
+
+  @Bean
+  @ConditionalOnMissingBean(WxOpenConfigStorage.class)
+  public WxOpenConfigStorage wxOpenConfigStorage() {
+    WxOpenInMemoryConfigStorage config = new WxOpenInMemoryConfigStorage();
+
+    WxOpenProperties.ConfigStorage configStorageProperties = properties.getConfigStorage();
+    config.setWxOpenInfo(properties.getAppId(), properties.getSecret(), properties.getToken(), properties.getAesKey());
+    config.setHttpProxyHost(configStorageProperties.getHttpProxyHost());
+    config.setHttpProxyUsername(configStorageProperties.getHttpProxyUsername());
+    config.setHttpProxyPassword(configStorageProperties.getHttpProxyPassword());
+    if (configStorageProperties.getHttpProxyPort() != null) {
+      config.setHttpProxyPort(configStorageProperties.getHttpProxyPort());
+    }
+    return config;
+  }
+}

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/WxOpenInRedisConfigStorageConfiguration.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/WxOpenInRedisConfigStorageConfiguration.java
@@ -1,0 +1,85 @@
+package com.binarywang.spring.starter.wxjava.open.config.storage;
+
+import com.binarywang.spring.starter.wxjava.open.properties.RedisProperties;
+import com.binarywang.spring.starter.wxjava.open.properties.WxOpenProperties;
+import lombok.RequiredArgsConstructor;
+import me.chanjar.weixin.common.redis.JedisWxRedisOps;
+import me.chanjar.weixin.common.redis.WxRedisOps;
+import me.chanjar.weixin.open.api.WxOpenConfigStorage;
+import me.chanjar.weixin.open.api.impl.WxOpenInMemoryConfigStorage;
+import me.chanjar.weixin.open.api.impl.WxOpenInRedisConfigStorage;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+/**
+ * @author yl
+ */
+@Configuration
+@ConditionalOnProperty(
+  prefix = WxOpenProperties.PREFIX + ".config-storage", name = "type", havingValue = "jedis"
+)
+@ConditionalOnClass({JedisPool.class, JedisPoolConfig.class})
+@RequiredArgsConstructor
+public class WxOpenInRedisConfigStorageConfiguration {
+  private final WxOpenProperties properties;
+  private final ApplicationContext applicationContext;
+
+  @Bean
+  @ConditionalOnMissingBean(WxOpenConfigStorage.class)
+  public WxOpenConfigStorage wxOpenConfigStorage() {
+    WxOpenInMemoryConfigStorage config = getWxOpenInRedisConfigStorage();
+
+    WxOpenProperties.ConfigStorage configStorageProperties = properties.getConfigStorage();
+    config.setWxOpenInfo(properties.getAppId(), properties.getSecret(), properties.getToken(), properties.getAesKey());
+    config.setHttpProxyHost(configStorageProperties.getHttpProxyHost());
+    config.setHttpProxyUsername(configStorageProperties.getHttpProxyUsername());
+    config.setHttpProxyPassword(configStorageProperties.getHttpProxyPassword());
+    if (configStorageProperties.getHttpProxyPort() != null) {
+      config.setHttpProxyPort(configStorageProperties.getHttpProxyPort());
+    }
+    return config;
+  }
+
+  private WxOpenInRedisConfigStorage getWxOpenInRedisConfigStorage() {
+    RedisProperties redisProperties = properties.getConfigStorage().getRedis();
+    JedisPool jedisPool;
+    if (redisProperties != null && StringUtils.isNotEmpty(redisProperties.getHost())) {
+      jedisPool = getJedisPool();
+    } else {
+      jedisPool = applicationContext.getBean(JedisPool.class);
+    }
+    WxRedisOps redisOps = new JedisWxRedisOps(jedisPool);
+    return new WxOpenInRedisConfigStorage(redisOps, properties.getConfigStorage().getKeyPrefix());
+  }
+
+  private JedisPool getJedisPool() {
+    WxOpenProperties.ConfigStorage storage = properties.getConfigStorage();
+    RedisProperties redis = storage.getRedis();
+
+    JedisPoolConfig config = new JedisPoolConfig();
+    if (redis.getMaxActive() != null) {
+      config.setMaxTotal(redis.getMaxActive());
+    }
+    if (redis.getMaxIdle() != null) {
+      config.setMaxIdle(redis.getMaxIdle());
+    }
+    if (redis.getMaxWaitMillis() != null) {
+      config.setMaxWaitMillis(redis.getMaxWaitMillis());
+    }
+    if (redis.getMinIdle() != null) {
+      config.setMinIdle(redis.getMinIdle());
+    }
+    config.setTestOnBorrow(true);
+    config.setTestWhileIdle(true);
+
+    return new JedisPool(config, redis.getHost(), redis.getPort(),
+      redis.getTimeout(), redis.getPassword(), redis.getDatabase());
+  }
+}

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/WxOpenInRedisTemplateConfigStorageConfiguration.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/WxOpenInRedisTemplateConfigStorageConfiguration.java
@@ -1,0 +1,52 @@
+package com.binarywang.spring.starter.wxjava.open.config.storage;
+
+import com.binarywang.spring.starter.wxjava.open.properties.WxOpenProperties;
+import lombok.RequiredArgsConstructor;
+import me.chanjar.weixin.common.redis.RedisTemplateWxRedisOps;
+import me.chanjar.weixin.common.redis.WxRedisOps;
+import me.chanjar.weixin.open.api.WxOpenConfigStorage;
+import me.chanjar.weixin.open.api.impl.WxOpenInMemoryConfigStorage;
+import me.chanjar.weixin.open.api.impl.WxOpenInRedisConfigStorage;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+/**
+ * @author yl
+ */
+@Configuration
+@ConditionalOnProperty(
+  prefix = WxOpenProperties.PREFIX + ".config-storage", name = "type", havingValue = "redistemplate"
+)
+@ConditionalOnClass(StringRedisTemplate.class)
+@RequiredArgsConstructor
+public class WxOpenInRedisTemplateConfigStorageConfiguration {
+  private final WxOpenProperties properties;
+  private final ApplicationContext applicationContext;
+
+  @Bean
+  @ConditionalOnMissingBean(WxOpenConfigStorage.class)
+  public WxOpenConfigStorage wxOpenConfigStorage() {
+    WxOpenInMemoryConfigStorage config = getWxOpenInRedisTemplateConfigStorage();
+
+    WxOpenProperties.ConfigStorage configStorageProperties = properties.getConfigStorage();
+    config.setWxOpenInfo(properties.getAppId(), properties.getSecret(), properties.getToken(), properties.getAesKey());
+    config.setHttpProxyHost(configStorageProperties.getHttpProxyHost());
+    config.setHttpProxyUsername(configStorageProperties.getHttpProxyUsername());
+    config.setHttpProxyPassword(configStorageProperties.getHttpProxyPassword());
+    if (configStorageProperties.getHttpProxyPort() != null) {
+      config.setHttpProxyPort(configStorageProperties.getHttpProxyPort());
+    }
+    return config;
+  }
+
+  private WxOpenInRedisConfigStorage getWxOpenInRedisTemplateConfigStorage() {
+    StringRedisTemplate redisTemplate = applicationContext.getBean(StringRedisTemplate.class);
+    WxRedisOps redisOps = new RedisTemplateWxRedisOps(redisTemplate);
+    return new WxOpenInRedisConfigStorage(redisOps, properties.getConfigStorage().getKeyPrefix());
+  }
+}

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/WxOpenInRedissonConfigStorageConfiguration.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/WxOpenInRedissonConfigStorageConfiguration.java
@@ -1,0 +1,76 @@
+package com.binarywang.spring.starter.wxjava.open.config.storage;
+
+import com.binarywang.spring.starter.wxjava.open.properties.RedisProperties;
+import com.binarywang.spring.starter.wxjava.open.properties.WxOpenProperties;
+import lombok.RequiredArgsConstructor;
+import me.chanjar.weixin.common.redis.RedissonWxRedisOps;
+import me.chanjar.weixin.common.redis.WxRedisOps;
+import me.chanjar.weixin.open.api.WxOpenConfigStorage;
+import me.chanjar.weixin.open.api.impl.WxOpenInMemoryConfigStorage;
+import me.chanjar.weixin.open.api.impl.WxOpenInRedisConfigStorage;
+import org.apache.commons.lang3.StringUtils;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.config.TransportMode;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author yl
+ */
+@Configuration
+@ConditionalOnProperty(
+  prefix = WxOpenProperties.PREFIX + ".config-storage", name = "type", havingValue = "redisson"
+)
+@ConditionalOnClass({Redisson.class, RedissonClient.class})
+@RequiredArgsConstructor
+public class WxOpenInRedissonConfigStorageConfiguration {
+  private final WxOpenProperties properties;
+  private final ApplicationContext applicationContext;
+
+  @Bean
+  @ConditionalOnMissingBean(WxOpenConfigStorage.class)
+  public WxOpenConfigStorage wxOpenConfigStorage() {
+    WxOpenInMemoryConfigStorage config = getWxOpenInRedissonConfigStorage();
+
+    WxOpenProperties.ConfigStorage configStorageProperties = properties.getConfigStorage();
+    config.setWxOpenInfo(properties.getAppId(), properties.getSecret(), properties.getToken(), properties.getAesKey());
+    config.setHttpProxyHost(configStorageProperties.getHttpProxyHost());
+    config.setHttpProxyUsername(configStorageProperties.getHttpProxyUsername());
+    config.setHttpProxyPassword(configStorageProperties.getHttpProxyPassword());
+    if (configStorageProperties.getHttpProxyPort() != null) {
+      config.setHttpProxyPort(configStorageProperties.getHttpProxyPort());
+    }
+    return config;
+  }
+
+  private WxOpenInRedisConfigStorage getWxOpenInRedissonConfigStorage() {
+    RedisProperties redisProperties = properties.getConfigStorage().getRedis();
+    RedissonClient redissonClient;
+    if (redisProperties != null && StringUtils.isNotEmpty(redisProperties.getHost())) {
+      redissonClient = getRedissonClient();
+    } else {
+      redissonClient = applicationContext.getBean(RedissonClient.class);
+    }
+    WxRedisOps redisOps = new RedissonWxRedisOps(redissonClient);
+    return new WxOpenInRedisConfigStorage(redisOps, properties.getConfigStorage().getKeyPrefix());
+  }
+
+  private RedissonClient getRedissonClient() {
+    WxOpenProperties.ConfigStorage storage = properties.getConfigStorage();
+    RedisProperties redis = storage.getRedis();
+
+    Config config = new Config();
+    config.useSingleServer()
+      .setAddress("redis://" + redis.getHost() + ":" + redis.getPort())
+      .setDatabase(redis.getDatabase())
+      .setPassword(redis.getPassword());
+    config.setTransportMode(TransportMode.NIO);
+    return Redisson.create(config);
+  }
+}

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/properties/WxOpenProperties.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/properties/WxOpenProperties.java
@@ -2,6 +2,7 @@ package com.binarywang.spring.starter.wxjava.open.properties;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.io.Serializable;
 
@@ -62,6 +63,7 @@ public class WxOpenProperties {
     /**
      * redis连接配置.
      */
+    @NestedConfigurationProperty
     private RedisProperties redis = new RedisProperties();
 
     /**
@@ -96,10 +98,6 @@ public class WxOpenProperties {
      * 内存.
      */
     memory,
-    /**
-     * redis.
-     */
-    redis,
     /**
      * jedis.
      */

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.binarywang.spring.starter.wxjava.open.config.WxOpenAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.binarywang.spring.starter.wxjava.open.config.WxOpenAutoConfiguration


### PR DESCRIPTION
优化使用 wx-java-open-spring-boot-starter 注册 ConfigStorage 需要同时依赖 jedis、redissson、spring-data-redis 包，否则启动报错的问题