### PR TITLE
修复获取AccessToken时ApiHostUrl未生效

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceHttpClientImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceHttpClientImpl.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import me.chanjar.weixin.common.util.http.HttpType;
 import me.chanjar.weixin.common.util.http.apache.ApacheHttpClientBuilder;
 import me.chanjar.weixin.common.util.http.apache.DefaultApacheHttpClientBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -60,7 +61,12 @@ public class WxMaServiceHttpClientImpl extends BaseWxMaServiceImpl {
 
   @Override
   protected String doGetAccessTokenRequest() throws IOException {
-    String url = String.format(WxMaService.GET_ACCESS_TOKEN_URL, this.getWxMaConfig().getAppid(), this.getWxMaConfig().getSecret());
+
+    String url = StringUtils.isNotEmpty(this.getWxMaConfig().getApiHostUrl()) ?
+      WxMaService.GET_ACCESS_TOKEN_URL.replace("https://api.weixin.qq.com", this.getWxMaConfig().getApiHostUrl()) :
+      WxMaService.GET_ACCESS_TOKEN_URL;
+    
+    url = String.format(url, this.getWxMaConfig().getAppid(), this.getWxMaConfig().getSecret());
 
     HttpGet httpGet = null;
     CloseableHttpResponse response = null;

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceJoddHttpImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceJoddHttpImpl.java
@@ -7,6 +7,7 @@ import jodd.http.HttpRequest;
 import jodd.http.ProxyInfo;
 import jodd.http.net.SocketHttpConnectionProvider;
 import me.chanjar.weixin.common.util.http.HttpType;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 
@@ -45,7 +46,11 @@ public class WxMaServiceJoddHttpImpl extends BaseWxMaServiceImpl<HttpConnectionP
 
   @Override
   protected String doGetAccessTokenRequest() throws IOException {
-    String url = String.format(WxMaService.GET_ACCESS_TOKEN_URL, this.getWxMaConfig().getAppid(), this.getWxMaConfig().getSecret());
+    String url = StringUtils.isNotEmpty(this.getWxMaConfig().getApiHostUrl()) ?
+      WxMaService.GET_ACCESS_TOKEN_URL.replace("https://api.weixin.qq.com", this.getWxMaConfig().getApiHostUrl()) :
+      WxMaService.GET_ACCESS_TOKEN_URL;
+
+    url = String.format(url, this.getWxMaConfig().getAppid(), this.getWxMaConfig().getSecret());
     HttpRequest request = HttpRequest.get(url);
     if (this.getRequestHttpProxy() != null) {
       SocketHttpConnectionProvider provider = new SocketHttpConnectionProvider();

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceOkHttpImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceOkHttpImpl.java
@@ -5,6 +5,7 @@ import cn.binarywang.wx.miniapp.config.WxMaConfig;
 import me.chanjar.weixin.common.util.http.HttpType;
 import me.chanjar.weixin.common.util.http.okhttp.OkHttpProxyInfo;
 import okhttp3.*;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -63,7 +64,11 @@ public class WxMaServiceOkHttpImpl extends BaseWxMaServiceImpl<OkHttpClient, OkH
 
   @Override
   protected String doGetAccessTokenRequest() throws IOException {
-    String url = String.format(WxMaService.GET_ACCESS_TOKEN_URL, this.getWxMaConfig().getAppid(), this.getWxMaConfig().getSecret());
+    String url = StringUtils.isNotEmpty(this.getWxMaConfig().getApiHostUrl()) ?
+      WxMaService.GET_ACCESS_TOKEN_URL.replace("https://api.weixin.qq.com", this.getWxMaConfig().getApiHostUrl()) :
+      WxMaService.GET_ACCESS_TOKEN_URL;
+
+    url = String.format(url, this.getWxMaConfig().getAppid(), this.getWxMaConfig().getSecret());
     Request request = new Request.Builder().url(url).get().build();
     try (Response response = getRequestHttpClient().newCall(request).execute()) {
       return Objects.requireNonNull(response.body()).string();


### PR DESCRIPTION
doGetAccessTokenRequest方法实现时，直接使用代码中写死的url去获取AccessToken，WxMaConfig中设置的apiHostUrl 未生效；
修复此问题。