### PR TITLE
:bug: 修复微信支付V3签名/验签的换行符错误

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/result/WxPayUnifiedOrderV3Result.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/result/WxPayUnifiedOrderV3Result.java
@@ -83,7 +83,7 @@ public class WxPayUnifiedOrderV3Result implements Serializable {
     private String paySign;
 
     private String getSignStr() {
-      return String.format("%s%n%s%n%s%n%s%n", appId, timeStamp, nonceStr, packageValue);
+      return String.format("%s\n%s\n%s\n%s\n", appId, timeStamp, nonceStr, packageValue);
     }
   }
 

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BusinessCircleServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BusinessCircleServiceImpl.java
@@ -46,7 +46,7 @@ public class BusinessCircleServiceImpl implements BusinessCircleService {
    * @return true:校验通过 false:校验不通过
    */
   private boolean verifyNotifySign(SignatureHeader header, String data) {
-    String beforeSign = String.format("%s%n%s%n%s%n", header.getTimeStamp(), header.getNonce(), data);
+    String beforeSign = String.format("%s\n%s\n%s\n", header.getTimeStamp(), header.getNonce(), data);
     return payService.getConfig().getVerifier().verify(header.getSerialNo(),
       beforeSign.getBytes(StandardCharsets.UTF_8), header.getSigned());
   }

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/MarketingFavorServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/MarketingFavorServiceImpl.java
@@ -177,7 +177,7 @@ public class MarketingFavorServiceImpl implements MarketingFavorService {
    * @return true:校验通过 false:校验不通过
    */
   private boolean verifyNotifySign(SignatureHeader header, String data) {
-    String beforeSign = String.format("%s%n%s%n%s%n", header.getTimeStamp(), header.getNonce(), data);
+    String beforeSign = String.format("%s\n%s\n%s\n", header.getTimeStamp(), header.getNonce(), data);
     return payService.getConfig().getVerifier().verify(header.getSerialNo(),
       beforeSign.getBytes(StandardCharsets.UTF_8), header.getSigned());
   }

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/PayScoreServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/PayScoreServiceImpl.java
@@ -303,7 +303,7 @@ public class PayScoreServiceImpl implements PayScoreService {
    * @return true:校验通过 false:校验不通过
    */
   private boolean verifyNotifySign(SignatureHeader header, String data) {
-    String beforeSign = String.format("%s%n%s%n%s%n", header.getTimeStamp(), header.getNonce(), data);
+    String beforeSign = String.format("%s\n%s\n%s\n", header.getTimeStamp(), header.getNonce(), data);
     return payService.getConfig().getVerifier().verify(header.getSerialNo(),
       beforeSign.getBytes(StandardCharsets.UTF_8), header.getSigned());
   }


### PR DESCRIPTION
参考微信支付文档：
https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_4.shtml
https://pay.weixin.qq.com/wiki/doc/apiv3/wechatpay/wechatpay4_0.shtml

![image](https://user-images.githubusercontent.com/28685179/129014679-8ed96424-17e5-4814-b5e7-7ae4e9de7379.png)
![image](https://user-images.githubusercontent.com/28685179/129014740-db68b44f-7fe5-48a3-a764-b9a46df93905.png)

签名时使用的换行符必须是`\n`，因此不应使用`%n`，这会导致windows平台下签名错误