### PR TITLE
修复OKhttp与Jodd的生成小程序码实现类当微信后端报错时不会抛异常问题

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/JoddHttpQrcodeFileRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/JoddHttpQrcodeFileRequestExecutor.java
@@ -57,12 +57,15 @@ public class JoddHttpQrcodeFileRequestExecutor extends QrcodeRequestExecutor<Htt
     HttpResponse response = request.send();
     response.charset(StandardCharsets.UTF_8.name());
     String contentTypeHeader = response.header("Content-Type");
-    if (MimeTypes.MIME_TEXT_PLAIN.equals(contentTypeHeader)) {
+    if (MimeTypes.MIME_APPLICATION_JSON.equals(contentTypeHeader)) {
       String responseContent = response.bodyText();
-      throw new WxErrorException(WxError.fromJson(responseContent, WxType.MiniApp));
+      throw new WxErrorException(WxError.fromJson(responseContent, wxType));
     }
     try (InputStream inputStream = new ByteArrayInputStream(response.bodyBytes())) {
-      return FileUtils.createTmpFile(inputStream, UUID.randomUUID().toString(), "jpg");
+      if (StringUtils.isBlank(filePath)) {
+        return FileUtils.createTmpFile(inputStream, UUID.randomUUID().toString(), "jpg");
+      }
+      return FileUtils.createTmpFile(inputStream, UUID.randomUUID().toString(), "jpg", Paths.get(filePath).toFile());
     }
   }
 }

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/JoddQrcodeBytesRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/JoddQrcodeBytesRequestExecutor.java
@@ -1,0 +1,55 @@
+package cn.binarywang.wx.miniapp.executor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import cn.binarywang.wx.miniapp.bean.AbstractWxMaQrcodeWrapper;
+import jodd.http.HttpConnectionProvider;
+import jodd.http.HttpRequest;
+import jodd.http.HttpResponse;
+import jodd.http.ProxyInfo;
+import jodd.net.MimeTypes;
+import me.chanjar.weixin.common.enums.WxType;
+import me.chanjar.weixin.common.error.WxError;
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.http.RequestHttp;
+
+/**
+ * @author vania
+ * @since 2021/09/06
+ */
+public class JoddQrcodeBytesRequestExecutor extends QrcodeBytesRequestExecutor<HttpConnectionProvider, ProxyInfo> {
+
+
+  public JoddQrcodeBytesRequestExecutor(RequestHttp<HttpConnectionProvider, ProxyInfo> requestHttp) {
+    super(requestHttp);
+  }
+
+  /**
+   * 执行http请求.
+   *
+   * @param uri           uri
+   * @param qrcodeWrapper 数据
+   * @param wxType        微信模块类型
+   * @return 响应结果
+   * @throws WxErrorException 自定义异常
+   * @throws IOException      io异常
+   */
+  @Override
+  public byte[] execute(String uri, AbstractWxMaQrcodeWrapper qrcodeWrapper, WxType wxType) throws WxErrorException, IOException {
+      HttpRequest request = HttpRequest.get(uri);
+      if (requestHttp.getRequestHttpProxy() != null) {
+        requestHttp.getRequestHttpClient().useProxy(requestHttp.getRequestHttpProxy());
+      }
+      request.withConnectionProvider(requestHttp.getRequestHttpClient());
+
+      HttpResponse response = request.send();
+      response.charset(StandardCharsets.UTF_8.name());
+      String contentTypeHeader = response.header("Content-Type");
+      if (MimeTypes.MIME_APPLICATION_JSON.equals(contentTypeHeader)) {
+        String responseContent = response.bodyText();
+        throw new WxErrorException(WxError.fromJson(responseContent, wxType));
+      }
+      return response.bodyBytes();
+  }
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/OkHttpQrcodeBytesRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/OkHttpQrcodeBytesRequestExecutor.java
@@ -35,13 +35,13 @@ public class OkHttpQrcodeBytesRequestExecutor extends QrcodeBytesRequestExecutor
    */
   @Override
   public byte[] execute(String uri, AbstractWxMaQrcodeWrapper qrcodeWrapper, WxType wxType) throws WxErrorException, IOException {
-    RequestBody body = RequestBody.Companion.create(qrcodeWrapper.toJson(), MediaType.parse("text/plain; charset=utf-8"));
+    RequestBody body = RequestBody.Companion.create(qrcodeWrapper.toJson(), MediaType.parse("application/json; charset=utf-8"));
     Request request = new Request.Builder().url(uri).post(body).build();
     Response response = requestHttp.getRequestHttpClient().newCall(request).execute();
     String contentTypeHeader = response.header("Content-Type");
-    if ("text/plain".equals(contentTypeHeader)) {
+    if (null != contentTypeHeader && contentTypeHeader.startsWith("application/json")) {
       String responseContent = response.body().string();
-      throw new WxErrorException(WxError.fromJson(responseContent, WxType.MP));
+      throw new WxErrorException(WxError.fromJson(responseContent, wxType));
     }
 
     try (InputStream inputStream = response.body().byteStream()) {

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/OkHttpQrcodeFileRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/OkHttpQrcodeFileRequestExecutor.java
@@ -41,13 +41,13 @@ public class OkHttpQrcodeFileRequestExecutor extends QrcodeRequestExecutor<OkHtt
    */
   @Override
   public File execute(String uri, AbstractWxMaQrcodeWrapper qrcodeWrapper, WxType wxType) throws WxErrorException, IOException {
-    RequestBody body = RequestBody.Companion.create(qrcodeWrapper.toJson(), MediaType.parse("text/plain; charset=utf-8"));
+    RequestBody body = RequestBody.Companion.create(qrcodeWrapper.toJson(), MediaType.parse("application/json; charset=utf-8"));
     Request request = new Request.Builder().url(uri).post(body).build();
     Response response = requestHttp.getRequestHttpClient().newCall(request).execute();
     String contentTypeHeader = response.header("Content-Type");
-    if ("text/plain".equals(contentTypeHeader)) {
+    if (null != contentTypeHeader && contentTypeHeader.startsWith("application/json")) {
       String responseContent = response.body().string();
-      throw new WxErrorException(WxError.fromJson(responseContent, WxType.MP));
+      throw new WxErrorException(WxError.fromJson(responseContent, wxType));
     }
 
     try (InputStream inputStream = response.body().byteStream()) {


### PR DESCRIPTION
1. 修复OKhttp与Jodd的生成小程序码实现类当微信后端报错时不会抛异常问题
2. 【小程序】生成小程序码增加Jodd返回byte[]实现