### PR TITLE
fix: 默认是Apache http，排除jodd-http依赖

### DIFF
--- a/weixin-java-pay/pom.xml
+++ b/weixin-java-pay/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.jodd</groupId>
       <artifactId>jodd-http</artifactId>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
项目中没有用到jodd-http，引入微信模块后会多出一个依赖来。微信支付模块默认Apache http。