### PR TITLE
【weixin-java-pay】修复某些情况下会抛出CannotResolveClassException异常错误的问题

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/result/BaseWxPayResult.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/result/BaseWxPayResult.java
@@ -150,6 +150,7 @@ public abstract class BaseWxPayResult {
     }
     XStream xstream = XStreamInitializer.getInstance();
     xstream.processAnnotations(clz);
+    xstream.setClassLoader(BaseWxPayResult.class.getClassLoader());
     T result = (T) xstream.fromXML(xmlString);
     result.setXmlString(xmlString);
     return result;


### PR DESCRIPTION
修复在某些情况下会抛出CannotResolveClassException错误的问题，具体原因不清楚，猜测可能是包里的类是由不同的类加载器加载导致的。此 commit 修复此问题。

See [nodecom.thoughtworks.xstream.mapper.CannotResolveClassException while using xstream under Kettle](https://stackoverflow.com/questions/9508292/nodecom-thoughtworks-xstream-mapper-cannotresolveclassexception-while-using-xstr)