### PR TITLE
refactor: remove unnecessary parentheses

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/session/StandardSessionManager.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/session/StandardSessionManager.java
@@ -98,7 +98,7 @@ public class StandardSessionManager implements WxSessionManager, InternalSession
 
     // Create a new session if requested and the response is not committed
     if (!create) {
-      return (null);
+      return null;
     }
 
     session = createSession(sessionId);
@@ -127,7 +127,7 @@ public class StandardSessionManager implements WxSessionManager, InternalSession
   @Override
   public InternalSession findSession(String id) {
     if (id == null) {
-      return (null);
+      return null;
     }
     return this.sessions.get(id);
   }
@@ -251,7 +251,7 @@ public class StandardSessionManager implements WxSessionManager, InternalSession
     if (this.log.isDebugEnabled()) {
       this.log.debug("End expire sessions {} processingTime {} expired sessions: {}", getName(), timeEnd - timeNow, expireHere);
     }
-    this.processingTime += (timeEnd - timeNow);
+    this.processingTime += timeEnd - timeNow;
 
   }
 
@@ -289,7 +289,7 @@ public class StandardSessionManager implements WxSessionManager, InternalSession
    */
   public String getName() {
 
-    return (name);
+    return name;
 
   }
 

--- a/weixin-java-qidian/src/test/java/me/chanjar/weixin/qidian/api/impl/WxQidianDialServiceImplTest.java
+++ b/weixin-java-qidian/src/test/java/me/chanjar/weixin/qidian/api/impl/WxQidianDialServiceImplTest.java
@@ -32,7 +32,7 @@ public class WxQidianDialServiceImplTest {
     IVRListResponse iVRListResponse = this.wxService.getDialService().getIVRList();
     Assert.assertEquals(iVRListResponse.getErrcode(), new Integer(0));
     log.info("ivr size:" + iVRListResponse.getNode().size());
-    Optional<Ivr> optional = iVRListResponse.getNode().stream().filter((o) -> o.getIvr_name().equals("自动接听需求测试"))
+    Optional<Ivr> optional = iVRListResponse.getNode().stream().filter(o -> o.getIvr_name().equals("自动接听需求测试"))
         .findFirst();
     Assert.assertTrue(optional.isPresent());
     Ivr ivr = optional.get();


### PR DESCRIPTION
Removes unnecessary parentheses from code where extra parentheses pairs are redundant.

Happy Hacktoberfest!

Co-authored-by: Moderne <team@moderne.io>