### PR TITLE
refactor: use explicit types on lambda arguments

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/apache/ApacheHttpDnsClientBuilder.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/apache/ApacheHttpDnsClientBuilder.java
@@ -48,7 +48,7 @@ public class ApacheHttpDnsClientBuilder implements ApacheHttpClientBuilder {
 
   private DnsResolver dnsResover;
 
-  private HttpRequestRetryHandler httpRequestRetryHandler = (exception, executionCount, context) -> false;
+  private HttpRequestRetryHandler httpRequestRetryHandler = (IOException exception, int executionCount, HttpContext context) -> false;
   private SSLConnectionSocketFactory sslConnectionSocketFactory = SSLConnectionSocketFactory.getSocketFactory();
   private PlainConnectionSocketFactory plainConnectionSocketFactory = PlainConnectionSocketFactory.getSocketFactory();
   private String httpProxyHost;

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/BaseWxCpServiceImplTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/BaseWxCpServiceImplTest.java
@@ -92,7 +92,7 @@ public class BaseWxCpServiceImplTest {
     RequestExecutor<Object, Object> re = mock(RequestExecutor.class);
 
     AtomicInteger counter = new AtomicInteger();
-    Mockito.when(re.execute(Mockito.anyString(), Mockito.any(), Mockito.any())).thenAnswer(invocation -> {
+    Mockito.when(re.execute(Mockito.anyString(), Mockito.any(), Mockito.any())).thenAnswer((InvocationOnMock invocation) -> {
       counter.incrementAndGet();
       WxError error = WxError.builder().errorCode(WxMpErrorMsgEnum.CODE_40001.getCode()).errorMsg(WxMpErrorMsgEnum.CODE_40001.getMsg()).build();
       throw new WxErrorException(error);

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/demo/WxCpDemoServer.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/demo/WxCpDemoServer.java
@@ -49,14 +49,14 @@ public class WxCpDemoServer {
       wxCpService = new WxCpServiceImpl();
       wxCpService.setWxCpConfigStorage(config);
 
-      WxCpMessageHandler handler = (wxMessage, context, wxService, sessionManager) -> {
+      WxCpMessageHandler handler = (WxCpXmlMessage wxMessage, Map context, WxCpService wxService, WxSessionManager sessionManager) -> {
         WxCpXmlOutTextMessage m = WxCpXmlOutMessage.TEXT().content("测试加密消息")
           .fromUser(wxMessage.getToUserName())
           .toUser(wxMessage.getFromUserName()).build();
         return m;
       };
 
-      WxCpMessageHandler oauth2handler = (wxMessage, context, wxService, sessionManager) -> {
+      WxCpMessageHandler oauth2handler = (WxCpXmlMessage wxMessage, Map context, WxCpService wxService, WxSessionManager sessionManager) -> {
         String href = "<a href=\""
           + wxService.getOauth2Service().buildAuthorizationUrl(wxCpConfigStorage.getOauth2redirectUri(), null)
           + "\">测试oauth2</a>";
@@ -78,7 +78,7 @@ public class WxCpDemoServer {
         .end()
         .rule()
         .event(WxCpConsts.EventType.CHANGE_CONTACT)
-        .handler((wxMessage, context, wxCpService, sessionManager) -> {
+        .handler((WxCpXmlMessage wxMessage, Map context, WxCpService wxCpService, WxSessionManager sessionManager) -> {
           System.out.println("通讯录发生变更");
           return null;
         })

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImplTest.java
@@ -127,7 +127,7 @@ public class WxMaServiceImplTest {
     RequestExecutor<Object, Object> re = mock(RequestExecutor.class);
 
     AtomicInteger counter = new AtomicInteger();
-    Mockito.when(re.execute(Mockito.anyString(), Mockito.any(), Mockito.any())).thenAnswer(invocation -> {
+    Mockito.when(re.execute(Mockito.anyString(), Mockito.any(), Mockito.any())).thenAnswer((InvocationOnMock invocation) -> {
       counter.incrementAndGet();
       WxError error = WxError.builder().errorCode(WxMpErrorMsgEnum.CODE_40001.getCode()).errorMsg(WxMpErrorMsgEnum.CODE_40001.getMsg()).build();
       throw new WxErrorException(error);

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImplTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImplTest.java
@@ -237,7 +237,7 @@ public class BaseWxMpServiceImplTest {
     RequestExecutor<Object, Object> re = mock(RequestExecutor.class);
 
     AtomicInteger counter = new AtomicInteger();
-    Mockito.when(re.execute(Mockito.anyString(), Mockito.any(), Mockito.any())).thenAnswer(invocation -> {
+    Mockito.when(re.execute(Mockito.anyString(), Mockito.any(), Mockito.any())).thenAnswer((InvocationOnMock invocation) -> {
       counter.incrementAndGet();
       WxError error = WxError.builder().errorCode(WxMpErrorMsgEnum.CODE_40001.getCode()).errorMsg(WxMpErrorMsgEnum.CODE_40001.getMsg()).build();
       throw new WxErrorException(error);


### PR DESCRIPTION
Adds explicit types on lambda arguments, which are otherwise optional. This can make the code clearer and easier to read.

🎉 Happy Hacktoberfest! 🎉 

Co-authored-by: Moderne <team@moderne.io>