### PR TITLE
【微信小程序】WxMaShopPayInfo的支付方式参数设置不正确

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/WxMaShopPayInfo.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/WxMaShopPayInfo.java
@@ -13,13 +13,13 @@ public class WxMaShopPayInfo implements Serializable {
   private static final long serialVersionUID = 687488209024968647L;
 
   /**
-   * 支付方式（目前只有"微信支付"）
+   * 支付方式（支付方式，0:微信支付，1: 货到付款，2：商家会员储蓄卡, 默认0)
    * <pre>
    * 是否必填：是
    * </pre>
    */
-  @SerializedName("pay_method")
-  private String payMethod;
+  @SerializedName("pay_method_type")
+  private Integer payMethodType;
 
   /**
    * 预支付ID


### PR DESCRIPTION
https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/business-capabilities/ministore/minishopopencomponent2/API/order/add_order.html

生成订单的支付方式不正确