### PR TITLE
新增企微获取企业群发记录及结果

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/apache/ApacheHttpDnsClientBuilder.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/apache/ApacheHttpDnsClientBuilder.java
@@ -20,10 +20,12 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -52,9 +54,11 @@ public class ApacheHttpDnsClientBuilder implements ApacheHttpClientBuilder {
   private SSLConnectionSocketFactory sslConnectionSocketFactory = SSLConnectionSocketFactory.getSocketFactory();
   private PlainConnectionSocketFactory plainConnectionSocketFactory = PlainConnectionSocketFactory.getSocketFactory();
   private String httpProxyHost;
+
   private int httpProxyPort;
   private String httpProxyUsername;
   private String httpProxyPassword;
+
 
   /**
    * 闲置连接监控线程.

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
@@ -20,8 +20,8 @@ import me.chanjar.weixin.cp.bean.external.WxCpUserTransferCustomerReq;
 import me.chanjar.weixin.cp.bean.external.WxCpUserTransferCustomerResp;
 import me.chanjar.weixin.cp.bean.external.WxCpUserTransferResultResp;
 import me.chanjar.weixin.cp.bean.external.WxCpWelcomeMsg;
-import me.chanjar.weixin.cp.bean.external.contact.WxCpExternalContactBatchInfo;
-import me.chanjar.weixin.cp.bean.external.contact.WxCpExternalContactInfo;
+import me.chanjar.weixin.cp.bean.external.contact.*;
+import me.chanjar.weixin.cp.bean.oa.WxCpApprovalInfoQueryFilter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Date;
@@ -586,5 +586,52 @@ public interface WxCpExternalContactService {
    */
   WxCpBaseResp markTag(String userid, String externalUserid, String[] addTag, String[] removeTag) throws WxErrorException;
 
+
+  /**
+   * <pre>
+   * 企业和第三方应用可通过此接口获取企业与成员的群发记录。
+   * https://work.weixin.qq.com/api/doc/90000/90135/93338
+   * </pre>
+   *
+   * @param chatType         群发任务的类型，默认为single，表示发送给客户，group表示发送给客户群
+   * @param startTime        群发任务记录开始时间
+   * @param endTime          群发任务记录结束时间
+   * @param creator           群发任务创建人企业账号id
+   * @param filterType       创建人类型。0：企业发表 1：个人发表 2：所有，包括个人创建以及企业创建，默认情况下为所有类型
+   * @param limit             返回的最大记录数，整型，最大值100，默认值50，超过最大值时取默认值
+   * @param cursor            用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+   * @return wx cp base resp
+   * @throws WxErrorException the wx error exception
+   */
+  WxCpGroupMsgListResult getGroupMsgListV2(String chatType, @NonNull Date startTime, @NonNull Date endTime, String creator, Integer filterType, Integer limit, String cursor) throws WxErrorException;
+
+  /**
+   * <pre>
+   * 企业和第三方应用可通过此接口获取企业与成员的群发记录。
+   * https://work.weixin.qq.com/api/doc/90000/90135/93338#获取企业群发成员执行结果
+   * </pre>
+   *
+   * @param msgid             群发消息的id，通过获取群发记录列表接口返回
+   * @param userid            发送成员userid，通过获取群发成员发送任务列表接口返回
+   * @param limit             返回的最大记录数，整型，最大值1000，默认值500，超过最大值时取默认值
+   * @param cursor            用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+   * @return wx cp base resp
+   * @throws WxErrorException the wx error exception
+   */
+  WxCpGroupMsgSendResult getGroupMsgSendResult(String msgid, String userid, Integer limit, String cursor) throws WxErrorException;
+
+  /**
+   * <pre>
+   * 获取群发成员发送任务列表。
+   * https://work.weixin.qq.com/api/doc/90000/90135/93338#获取群发成员发送任务列表
+   * </pre>
+   *
+   * @param msgid             群发消息的id，通过获取群发记录列表接口返回
+   * @param limit             返回的最大记录数，整型，最大值1000，默认值500，超过最大值时取默认值
+   * @param cursor            用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+   * @return wx cp base resp
+   * @throws WxErrorException the wx error exception
+   */
+   WxCpGroupMsgTaskResult getGroupMsgTask(String msgid, Integer limit, String cursor) throws WxErrorException;
 
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpExternalContactServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpExternalContactServiceImpl.java
@@ -31,8 +31,7 @@ import me.chanjar.weixin.cp.bean.external.WxCpUserTransferCustomerResp;
 import me.chanjar.weixin.cp.bean.external.WxCpUserTransferResultResp;
 import me.chanjar.weixin.cp.bean.external.WxCpUserWithExternalPermission;
 import me.chanjar.weixin.cp.bean.external.WxCpWelcomeMsg;
-import me.chanjar.weixin.cp.bean.external.contact.WxCpExternalContactBatchInfo;
-import me.chanjar.weixin.cp.bean.external.contact.WxCpExternalContactInfo;
+import me.chanjar.weixin.cp.bean.external.contact.*;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -448,5 +447,87 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(MARK_TAG);
     final String result = this.mainService.post(url, json.toString());
     return WxCpBaseResp.fromJson(result);
+  }
+
+  /**
+   * <pre>
+   * 企业和第三方应用可通过此接口获取企业与成员的群发记录。
+   * https://work.weixin.qq.com/api/doc/90000/90135/93338
+   * </pre>
+   *
+   * @param chatType   群发任务的类型，默认为single，表示发送给客户，group表示发送给客户群
+   * @param startTime  群发任务记录开始时间
+   * @param endTime    群发任务记录结束时间
+   * @param creator    群发任务创建人企业账号id
+   * @param filterType 创建人类型。0：企业发表 1：个人发表 2：所有，包括个人创建以及企业创建，默认情况下为所有类型
+   * @param limit      返回的最大记录数，整型，最大值100，默认值50，超过最大值时取默认值
+   * @param cursor     用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+   * @return wx cp base resp
+   * @throws WxErrorException the wx error exception
+   */
+  @Override
+  public WxCpGroupMsgListResult getGroupMsgListV2(String chatType, @NonNull Date startTime, @NonNull Date endTime, String creator, Integer filterType, Integer limit, String cursor) throws WxErrorException {
+    JsonObject json = new JsonObject();
+    json.addProperty("chat_type", chatType);
+    json.addProperty("start_time", startTime.getTime() / 1000);
+    json.addProperty("end_time", endTime.getTime() / 1000);
+    json.addProperty("creator", creator);
+    json.addProperty("filter_type", filterType);
+    json.addProperty("limit", limit);
+    json.addProperty("cursor", cursor);
+
+    final String url = this.mainService.getWxCpConfigStorage().getApiUrl(GET_GROUP_MSG_SEND_RESULT);
+    final String result = this.mainService.post(url, json.toString());
+    return WxCpGroupMsgListResult.fromJson(result);
+  }
+
+  /**
+   * <pre>
+   * 企业和第三方应用可通过此接口获取企业与成员的群发记录。
+   * https://work.weixin.qq.com/api/doc/90000/90135/93338#获取企业群发成员执行结果
+   * </pre>
+   *
+   * @param msgid  群发消息的id，通过获取群发记录列表接口返回
+   * @param userid 发送成员userid，通过获取群发成员发送任务列表接口返回
+   * @param limit  返回的最大记录数，整型，最大值1000，默认值500，超过最大值时取默认值
+   * @param cursor 用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+   * @return wx cp base resp
+   * @throws WxErrorException the wx error exception
+   */
+  @Override
+  public WxCpGroupMsgSendResult getGroupMsgSendResult(String msgid, String userid, Integer limit, String cursor) throws WxErrorException {
+    JsonObject json = new JsonObject();
+    json.addProperty("msgid", msgid);
+    json.addProperty("userid", userid);
+    json.addProperty("limit", limit);
+    json.addProperty("cursor", cursor);
+
+    final String url = this.mainService.getWxCpConfigStorage().getApiUrl(GET_GROUP_MSG_SEND_RESULT);
+    final String result = this.mainService.post(url, json.toString());
+    return WxCpGroupMsgSendResult.fromJson(result);
+  }
+
+  /**
+   * <pre>
+   * 获取群发成员发送任务列表。
+   * https://work.weixin.qq.com/api/doc/90000/90135/93338#获取群发成员发送任务列表
+   * </pre>
+   *
+   * @param msgid  群发消息的id，通过获取群发记录列表接口返回
+   * @param limit  返回的最大记录数，整型，最大值1000，默认值500，超过最大值时取默认值
+   * @param cursor 用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+   * @return wx cp base resp
+   * @throws WxErrorException the wx error exception
+   */
+  @Override
+  public WxCpGroupMsgTaskResult getGroupMsgTask(String msgid, Integer limit, String cursor) throws WxErrorException {
+    JsonObject json = new JsonObject();
+    json.addProperty("msgid", msgid);
+    json.addProperty("limit", limit);
+    json.addProperty("cursor", cursor);
+
+    final String url = this.mainService.getWxCpConfigStorage().getApiUrl(GET_GROUP_MSG_SEND_RESULT);
+    final String result = this.mainService.post(url, json.toString());
+    return WxCpGroupMsgTaskResult.fromJson(result);
   }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/contact/WxCpGroupMsgListResult.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/contact/WxCpGroupMsgListResult.java
@@ -1,0 +1,60 @@
+package me.chanjar.weixin.cp.bean.external.contact;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.bean.external.msg.Attachment;
+import me.chanjar.weixin.cp.bean.external.msg.Text;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * <pre>
+ * 获取企业群发成员执行结果
+ * 参考文档：https://work.weixin.qq.com/api/doc/90000/90135/93338
+ * </pre>
+ *
+ * @author <a href="https://github.com/wslongchen">Mr.Pan</a>
+ */
+@Getter
+@Setter
+public class WxCpGroupMsgListResult extends WxCpBaseResp implements Serializable {
+
+  private static final long serialVersionUID = 3464981991558716620L;
+
+  @SerializedName("group_msg_list")
+  private List<ExternalContactGroupMsgInfo> groupMsgList;
+
+  @SerializedName("next_cursor")
+  private String nextCursor;
+
+  @Getter
+  @Setter
+  public static class ExternalContactGroupMsgInfo implements Serializable {
+
+    private static final long serialVersionUID = 3108435608725559381L;
+    @SerializedName("msgid")
+    private String msgId;
+
+    private String creator;
+
+    private Text text;
+
+    private List<Attachment> attachments;
+
+    @SerializedName("create_type")
+    private Integer createType;
+
+    @SerializedName("create_time")
+    private Long createTime;
+
+  }
+
+  public static WxCpGroupMsgListResult fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpGroupMsgListResult.class);
+  }
+
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/contact/WxCpGroupMsgSendResult.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/contact/WxCpGroupMsgSendResult.java
@@ -1,0 +1,56 @@
+package me.chanjar.weixin.cp.bean.external.contact;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * <pre>
+ * 获取企业群发成员执行结果
+ * 参考文档：https://work.weixin.qq.com/api/doc/90000/90135/93338
+ * </pre>
+ *
+ * @author <a href="https://github.com/wslongchen">Mr.Pan</a>
+ */
+@Getter
+@Setter
+public class WxCpGroupMsgSendResult extends WxCpBaseResp implements Serializable {
+  private static final long serialVersionUID = -5166048319463473186L;
+
+  @SerializedName("send_list")
+  private List<ExternalContactGroupMsgSendInfo> sendList;
+
+  @SerializedName("next_cursor")
+  private String nextCursor;
+
+  @Getter
+  @Setter
+  public static class ExternalContactGroupMsgSendInfo implements Serializable {
+    private static final long serialVersionUID = 1500416806087532531L;
+
+    @SerializedName("external_userid")
+    private String externalUserId;
+
+    @SerializedName("chat_id")
+    private String chatId;
+
+    @SerializedName("userid")
+    private String userId;
+
+    private Integer status;
+
+    @SerializedName("send_time")
+    private Long sendTime;
+
+  }
+
+  public static WxCpGroupMsgSendResult fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpGroupMsgSendResult.class);
+  }
+
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/contact/WxCpGroupMsgTaskResult.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/contact/WxCpGroupMsgTaskResult.java
@@ -1,0 +1,50 @@
+package me.chanjar.weixin.cp.bean.external.contact;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * <pre>
+ * 获取群发成员发送任务列表
+ * 参考文档：https://work.weixin.qq.com/api/doc/90000/90135/93338
+ * </pre>
+ *
+ * @author <a href="https://github.com/wslongchen">Mr.Pan</a>
+ */
+@Getter
+@Setter
+public class WxCpGroupMsgTaskResult extends WxCpBaseResp implements Serializable {
+  private static final long serialVersionUID = -5166048319463473186L;
+
+  @SerializedName("task_list")
+  private List<ExternalContactGroupMsgTaskInfo> taskList;
+
+  @SerializedName("next_cursor")
+  private String nextCursor;
+
+  @Getter
+  @Setter
+  public static class ExternalContactGroupMsgTaskInfo implements Serializable {
+    private static final long serialVersionUID = 1500416806087532531L;
+
+    @SerializedName("userid")
+    private String userId;
+
+    private Integer status;
+
+    @SerializedName("send_time")
+    private Long sendTime;
+
+  }
+
+  public static WxCpGroupMsgTaskResult fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpGroupMsgTaskResult.class);
+  }
+
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -205,5 +205,9 @@ public interface WxCpApiPathConsts {
     String EDIT_CORP_TAG = "/cgi-bin/externalcontact/edit_corp_tag";
     String DEL_CORP_TAG = "/cgi-bin/externalcontact/del_corp_tag";
     String MARK_TAG = "/cgi-bin/externalcontact/mark_tag";
+
+    String GET_GROUP_MSG_SEND_RESULT = "/cgi-bin/externalcontact/get_groupmsg_send_result";
+    String GET_GROUP_MSG_TASK = "/cgi-bin/externalcontact/get_groupmsg_task";
+    String GET_GROUP_MSG_LIST_V2 = "/cgi-bin/externalcontact/get_groupmsg_list_v2";
   }
 }


### PR DESCRIPTION
# 新增企微获取企业群发记录及结果

### 简要描述
客户联系中可以进行群发，需要获取群发记录及结果


### 官方文档地址
[获取企业群发记录](https://work.weixin.qq.com/api/doc/90000/90135/93338)