### PR TITLE
:new: #2373 【小程序】urllink.generate通过env_version设置打开小程序的环境

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/urllink/GenerateUrlLinkRequest.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/urllink/GenerateUrlLinkRequest.java
@@ -1,9 +1,10 @@
 package cn.binarywang.wx.miniapp.bean.urllink;
 
-import cn.binarywang.wx.miniapp.json.WxMaGsonBuilder;
 import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
@@ -16,6 +17,8 @@ import java.io.Serializable;
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class GenerateUrlLinkRequest implements Serializable {
 
   private static final long serialVersionUID = -2183685760797791910L;
@@ -35,6 +38,15 @@ public class GenerateUrlLinkRequest implements Serializable {
    * </pre>
    */
   private String query;
+
+  /**
+   * 要打开的小程序版本。正式版为"release"，体验版为"trial"，开发版为"develop"，仅在微信外打开时生效。
+   * <pre>
+   * 是否必填： 否
+   * </pre>
+   */
+  @SerializedName("env_version")
+  private String envVersion = "release";
 
   /**
    * 生成的 URL Link 类型，到期失效：true，永久有效：false

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaLinkServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaLinkServiceImplTest.java
@@ -5,12 +5,14 @@ import cn.binarywang.wx.miniapp.bean.shortlink.GenerateShortLinkRequest;
 import cn.binarywang.wx.miniapp.bean.urllink.GenerateUrlLinkRequest;
 import cn.binarywang.wx.miniapp.test.ApiTestModule;
 import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import me.chanjar.weixin.common.error.WxErrorException;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
 @Test
 @Guice(modules = ApiTestModule.class)
+@Slf4j
 public class WxMaLinkServiceImplTest {
   @Inject
   private WxMaService wxMaService;
@@ -33,5 +35,18 @@ public class WxMaLinkServiceImplTest {
         .isPermanent(false).build());
     System.out.println("generate:");
     System.out.println(generate);
+  }
+
+  /**
+   * 多版本链接生成测试
+   * 开发时,仅支持IOS设备打开体验版及开发版
+   */
+  @Test
+  public void testGenerateMultiEnvUrlLink() throws WxErrorException {
+    String url = this.wxMaService.getLinkService().generateUrlLink(GenerateUrlLinkRequest.builder()
+      .path("")
+      .envVersion("trial")
+      .build());
+    log.info("generate url link = {}", url);
   }
 }


### PR DESCRIPTION
官方文档：[urllink.generate](https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/url-link/urllink.generate.html)，已支持通过变量设置链接打开的小程序环境，现补充参数提交。