### PR TITLE
Fix issue #2411: 【微信公众号>草稿箱>获取草稿列表】新增url、thumb_url字段

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/draft/WxMpDraftArticles.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/draft/WxMpDraftArticles.java
@@ -68,6 +68,16 @@ public class WxMpDraftArticles implements ToJson, Serializable {
    */
   @SerializedName("only_fans_can_comment")
   private Integer onlyFansCanComment;
+  /**
+   * 草稿的临时链接,点击图文消息跳转链接
+   */
+  @SerializedName("url")
+  private String url;
+  /**
+   * 图文消息的封面url
+   */
+  @SerializedName("thumb_url")
+  private String thumbUrl;
 
   public static WxMpDraftArticles fromJson(String json) {
     return WxGsonBuilder.create().fromJson(json, WxMpDraftArticles.class);


### PR DESCRIPTION
新增url（点击图文消息跳转链接）、thumb_url（图文消息的封面url）字段