### PR TITLE
fix: 小程序的条码/二维码识别的API请求方式应为post

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaImgProcServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaImgProcServiceImpl.java
@@ -35,7 +35,7 @@ public class WxMaImgProcServiceImpl implements WxImgProcService {
       //ignore
     }
 
-    final String result = this.service.get(String.format(QRCODE, imgUrl), null);
+    final String result = this.service.post(String.format(QRCODE, imgUrl), "");
     return WxImgProcQrCodeResult.fromJson(result);
   }
 


### PR DESCRIPTION
小程序的条码/二维码识别的API请求方式应为post
官方地址：https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/img/img.scanQRCode.html
