### PR TITLE
weixin-java-cp添加直属领导查询支持

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUser.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUser.java
@@ -70,6 +70,7 @@ public class WxCpUser implements Serializable {
   private String externalCorpName;
   private WechatChannels wechatChannels;
 
+  private String[] directLeader;
 
 
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/json/WxCpUserGsonAdapter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/json/WxCpUserGsonAdapter.java
@@ -89,6 +89,7 @@ public class WxCpUserGsonAdapter implements JsonDeserializer<WxCpUser>, JsonSeri
     user.setToInvite(GsonHelper.getBoolean(o, "to_invite"));
     user.setOpenUserId(GsonHelper.getString(o, "open_userid"));
     user.setMainDepartment(GsonHelper.getString(o, "main_department"));
+    user.setDirectLeader(GsonHelper.getStringArray(o, "direct_leader"));
 
     if (GsonHelper.isNotNull(o.get(EXTRA_ATTR))) {
       this.buildExtraAttrs(o, user);


### PR DESCRIPTION
企业微信官方在11月19号升级的版本中，添加支持了用户直属领导的接口字段