### PR TITLE
调整：此处应该是返回 对应key的字符串 值 而不是jsonElement 对象的toString值

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaLinkServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaLinkServiceImpl.java
@@ -29,7 +29,7 @@ public class WxMaLinkServiceImpl implements WxMaLinkService {
     String linkField = "url_link";
     JsonObject jsonObject = GsonParser.parse(result);
     if (jsonObject.has(linkField)) {
-      return jsonObject.get(linkField).toString();
+      return jsonObject.get(linkField).getAsString();
     }
     throw new WxErrorException("无url_link");
   }
@@ -40,7 +40,7 @@ public class WxMaLinkServiceImpl implements WxMaLinkService {
     String linkField = "link";
     JsonObject jsonObject = GsonParser.parse(result);
     if (jsonObject.has(linkField)) {
-      return jsonObject.get(linkField).toString();
+      return jsonObject.get(linkField).getAsString();
     }
     throw new WxErrorException("无link");
   }


### PR DESCRIPTION
此处应该是返回 对应key的字符串 值 而不是jsonElement 对象的toString值,看之前api取值时都是直接用的GsonHelper 里封装的方法，这个api提交者可能没注意到