### PR TITLE
[feature]微信支付V3接口中更新微信支付平台证书支持正向代理

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayHttpProxy.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayHttpProxy.java
@@ -1,0 +1,75 @@
+package com.github.binarywang.wxpay.config;
+
+
+import java.io.Serializable;
+
+/**
+ * 微信支付 HTTP Proxy 正向代理配置
+ *
+ * @author Long Yu
+ * @date 2021-12-28 15:49:03
+ */
+public class WxPayHttpProxy implements Serializable {
+
+  /**
+   * 代理主机
+   */
+  private String httpProxyHost;
+  /**
+   * 代理端口
+   */
+  private Integer httpProxyPort;
+  /**
+   * 代理用户名称
+   */
+  private String httpProxyUsername;
+  /**
+   * 代理密码
+   */
+  private String httpProxyPassword;
+
+  public WxPayHttpProxy() {
+  }
+
+  public WxPayHttpProxy(String httpProxyHost, Integer httpProxyPort, String httpProxyUsername, String httpProxyPassword) {
+    this.httpProxyHost = httpProxyHost;
+    this.httpProxyPort = httpProxyPort;
+    this.httpProxyUsername = httpProxyUsername;
+    this.httpProxyPassword = httpProxyPassword;
+  }
+
+  public String getHttpProxyHost() {
+    return httpProxyHost;
+  }
+
+  public void setHttpProxyHost(String httpProxyHost) {
+    this.httpProxyHost = httpProxyHost;
+  }
+
+  public Integer getHttpProxyPort() {
+    return httpProxyPort;
+  }
+
+  public void setHttpProxyPort(Integer httpProxyPort) {
+    this.httpProxyPort = httpProxyPort;
+  }
+
+  public String getHttpProxyUsername() {
+    return httpProxyUsername;
+  }
+
+  public void setHttpProxyUsername(String httpProxyUsername) {
+    this.httpProxyUsername = httpProxyUsername;
+  }
+
+  public String getHttpProxyPassword() {
+    return httpProxyPassword;
+  }
+
+  public void setHttpProxyPassword(String httpProxyPassword) {
+    this.httpProxyPassword = httpProxyPassword;
+  }
+
+
+
+}

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/util/HttpProxyUtils.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/util/HttpProxyUtils.java
@@ -1,0 +1,49 @@
+package com.github.binarywang.wxpay.util;
+
+import com.github.binarywang.wxpay.config.WxPayHttpProxy;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+/**
+ * 微信支付 HTTP Proxy 工具类
+ *
+ * @author Long Yu
+ * @date 2021-12-28 15:58:03
+ */
+public class HttpProxyUtils {
+
+  /**
+   * 配置 http 正向代理 可以实现内网服务通过代理调用接口
+   * 参考代码: WxPayServiceApacheHttpImpl 中的方法 createHttpClientBuilder
+   *
+   * @param wxPayHttpProxy 代理配置
+   * @param httpClientBuilder http构造参数
+   */
+  public static void initHttpProxy(HttpClientBuilder httpClientBuilder, WxPayHttpProxy wxPayHttpProxy) {
+    if(wxPayHttpProxy == null){
+      return;
+    }
+    if (StringUtils.isNotBlank(wxPayHttpProxy.getHttpProxyHost()) && wxPayHttpProxy.getHttpProxyPort() > 0) {
+      if (StringUtils.isEmpty(wxPayHttpProxy.getHttpProxyUsername())) {
+        wxPayHttpProxy.setHttpProxyUsername("whatever");
+      }
+
+      // 使用代理服务器 需要用户认证的代理服务器
+      CredentialsProvider provider = new BasicCredentialsProvider();
+      provider.setCredentials(new AuthScope(wxPayHttpProxy.getHttpProxyHost(), wxPayHttpProxy.getHttpProxyPort()),
+        new UsernamePasswordCredentials(wxPayHttpProxy.getHttpProxyUsername(), wxPayHttpProxy.getHttpProxyPassword()));
+      httpClientBuilder.setDefaultCredentialsProvider(provider);
+      httpClientBuilder.setProxy(new HttpHost(wxPayHttpProxy.getHttpProxyHost(), wxPayHttpProxy.getHttpProxyPort()));
+    }
+  }
+
+
+
+
+
+}


### PR DESCRIPTION
[feature]微信支付V3接口中更新微信支付平台证书支持正向代理
增加了2个文件，修改了2个文件，抽取上一个版本正向代理设置代码到工具类中