### PR TITLE
#2400 WxMaMessage 增加TemplateId、SubscribeStatusString等相关属性

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/WxMaSubscribeMsgEvent.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/WxMaSubscribeMsgEvent.java
@@ -1,0 +1,118 @@
+package cn.binarywang.wx.miniapp.bean;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import lombok.Data;
+import me.chanjar.weixin.common.util.xml.XStreamCDataConverter;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * WxMaSubscribeMsgEvent class
+ *  客户端订阅，服务端收到的通知
+ * @author dany
+ * @date 2021/12/31
+ */
+public class WxMaSubscribeMsgEvent {
+  /**
+   * https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/subscribe-message.html
+   */
+  @Data
+  @XStreamAlias("SubscribeMsgPopupEvent")
+  public static class SubscribeMsgPopupEvent implements Serializable {
+    private static final long serialVersionUID = 6319723189257161326L;
+    @XStreamImplicit(itemFieldName = "List")
+    private List<PopupEvent> list = new LinkedList<>();
+  }
+
+  @Data
+  @XStreamAlias("SubscribeMsgChangeEvent")
+  public static class SubscribeMsgChangeEvent implements Serializable {
+    private static final long serialVersionUID = 7705686111539437751L;
+    @XStreamImplicit(itemFieldName = "List")
+    private List<ChangeEvent> list = new LinkedList<>();
+  }
+
+  @Data
+  @XStreamAlias("SubscribeMsgSentEvent")
+  public static class SubscribeMsgSentEvent implements Serializable {
+    private static final long serialVersionUID = 7705686111539437751L;
+    @XStreamAlias("List")
+    private SentEvent list;
+  }
+
+
+  @Data
+  public static class PopupEvent implements Serializable {
+    private static final long serialVersionUID = 4934029303241387226L;
+    /**
+     * 模板id
+     */
+    @XStreamAlias("TemplateId")
+    @XStreamConverter(value = XStreamCDataConverter.class)
+    private String templateId;
+    /**
+     * 订阅结果（accept接收；reject拒收）
+     */
+    @XStreamAlias("SubscribeStatusString")
+    @XStreamConverter(value = XStreamCDataConverter.class)
+    private String subscribeStatusString;
+    /**
+     * 弹框场景，0代表在小程序页面内
+     */
+    @XStreamAlias("PopupScene")
+    private String popupScene;
+  }
+
+  @Data
+  public static class ChangeEvent implements Serializable {
+    private static final long serialVersionUID = 1523634146232757624L;
+    /**
+     * 模板id
+     */
+    @XStreamAlias("TemplateId")
+    @XStreamConverter(value = XStreamCDataConverter.class)
+    private String templateId;
+    /**
+     * 订阅结果（accept接收；reject拒收）
+     */
+    @XStreamAlias("SubscribeStatusString")
+    @XStreamConverter(value = XStreamCDataConverter.class)
+    private String subscribeStatusString;
+  }
+
+  @Data
+  public static class SentEvent implements Serializable {
+    private static final long serialVersionUID = -8734478345463177940L;
+    /**
+     * 模板id
+     */
+    @XStreamAlias("TemplateId")
+    @XStreamConverter(value = XStreamCDataConverter.class)
+    private String templateId;
+
+    @XStreamAlias("MsgID")
+    private String msgId;
+
+    @XStreamAlias("ErrorCode")
+    private String errorCode;
+
+    @XStreamAlias("ErrorStatus")
+    @XStreamConverter(value = XStreamCDataConverter.class)
+    private String errorStatus;
+  }
+
+  @Data
+  public static class WxMaSubscribeMsgEventJson implements Serializable {
+    private static final long serialVersionUID = -4820758280837190275L;
+
+    private SubscribeMsgPopupEvent popupEvents;
+
+    private SubscribeMsgChangeEvent changeEvents;
+
+    private SubscribeMsgSentEvent sentEvent;
+  }
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/json/WxMaGsonBuilder.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/json/WxMaGsonBuilder.java
@@ -1,6 +1,7 @@
 package cn.binarywang.wx.miniapp.json;
 
 import cn.binarywang.wx.miniapp.bean.WxMaSubscribeMessage;
+import cn.binarywang.wx.miniapp.bean.WxMaSubscribeMsgEvent;
 import cn.binarywang.wx.miniapp.bean.WxMaUniformMessage;
 import cn.binarywang.wx.miniapp.bean.analysis.WxMaRetainInfo;
 import cn.binarywang.wx.miniapp.bean.analysis.WxMaUserPortrait;
@@ -26,6 +27,7 @@ public class WxMaGsonBuilder {
     INSTANCE.registerTypeAdapter(WxMaVisitDistribution.class, new WxMaVisitDistributionGsonAdapter());
     INSTANCE.registerTypeAdapter(WxMaRetainInfo.class, new WxMaRetainInfoGsonAdapter());
     INSTANCE.registerTypeAdapter(WxMaUserPortrait.class, new WxMaUserPortraitGsonAdapter());
+    INSTANCE.registerTypeAdapter(WxMaSubscribeMsgEvent.WxMaSubscribeMsgEventJson.class, new WxMaSubscribeMsgEventJsonAdapter());
   }
 
   public static Gson create() {

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/json/adaptor/WxMaSubscribeMsgEventJsonAdapter.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/json/adaptor/WxMaSubscribeMsgEventJsonAdapter.java
@@ -1,0 +1,104 @@
+package cn.binarywang.wx.miniapp.json.adaptor;
+
+import cn.binarywang.wx.miniapp.bean.WxMaSubscribeMsgEvent;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Type;
+
+/**
+ * WxMaSubscribeMsgEventJsonAdapter class
+ *
+ * @author dany
+ * @date 2021/12/31
+ */
+@Slf4j
+public class WxMaSubscribeMsgEventJsonAdapter implements JsonDeserializer<WxMaSubscribeMsgEvent.WxMaSubscribeMsgEventJson> {
+  @Override
+  public WxMaSubscribeMsgEvent.WxMaSubscribeMsgEventJson deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    WxMaSubscribeMsgEvent.WxMaSubscribeMsgEventJson result = new WxMaSubscribeMsgEvent.WxMaSubscribeMsgEventJson();
+    if (json.isJsonArray()) {
+      JsonArray array = json.getAsJsonArray();
+      if (array.size() > 0) {
+        JsonObject obj = array.get(0).getAsJsonObject();
+        MsgEventTypeEnum eventType = detectMsgEventType(obj);
+        for (int i = 0; i < array.size(); ++i) {
+          obj = array.get(i).getAsJsonObject();
+          setField(result, eventType, obj);
+        }
+      }
+    } else {
+      JsonObject obj = json.getAsJsonObject();
+      MsgEventTypeEnum eventType = detectMsgEventType(obj);
+      setField(result, eventType, obj);
+    }
+    return result;
+  }
+
+  public enum MsgEventTypeEnum {
+    EVENT_POPUP,EVENT_CHANGE,EVENT_SENT;
+  }
+  private MsgEventTypeEnum detectMsgEventType(JsonObject  obj) {
+    JsonElement popupScene = obj.get("PopupScene");
+    if (popupScene != null) {
+      return MsgEventTypeEnum.EVENT_POPUP;
+    }
+
+    JsonElement msgId = obj.get("MsgID");
+    if (msgId != null) {
+      return MsgEventTypeEnum.EVENT_SENT;
+    }
+    JsonElement errorCode = obj.get("ErrorCode");
+    if (errorCode != null) {
+      return MsgEventTypeEnum.EVENT_SENT;
+    }
+    JsonElement errorStatus = obj.get("ErrorStatus");
+    if (errorStatus != null) {
+      return MsgEventTypeEnum.EVENT_SENT;
+    }
+
+    return MsgEventTypeEnum.EVENT_CHANGE;
+  }
+
+  private WxMaSubscribeMsgEvent.WxMaSubscribeMsgEventJson setField(WxMaSubscribeMsgEvent.WxMaSubscribeMsgEventJson target,
+                                                                   MsgEventTypeEnum eventType, JsonObject json) {
+    switch (eventType) {
+      case EVENT_POPUP:
+        if (target.getPopupEvents() == null) {
+          target.setPopupEvents(new WxMaSubscribeMsgEvent.SubscribeMsgPopupEvent());
+        }
+        WxMaSubscribeMsgEvent.PopupEvent popupEvent = new WxMaSubscribeMsgEvent.PopupEvent();
+        popupEvent.setTemplateId(json.get("TemplateId").getAsString());
+        popupEvent.setSubscribeStatusString(json.get("SubscribeStatusString").getAsString());
+        popupEvent.setPopupScene(json.get("PopupScene").getAsString());
+        target.getPopupEvents().getList().add(popupEvent);
+        break;
+      case EVENT_CHANGE:
+        if (target.getChangeEvents() == null) {
+          target.setChangeEvents(new WxMaSubscribeMsgEvent.SubscribeMsgChangeEvent());
+        }
+        WxMaSubscribeMsgEvent.ChangeEvent changeEvent = new WxMaSubscribeMsgEvent.ChangeEvent();
+        changeEvent.setTemplateId(json.get("TemplateId").getAsString());
+        changeEvent.setSubscribeStatusString(json.get("SubscribeStatusString").getAsString());
+        target.getChangeEvents().getList().add(changeEvent);
+        break;
+      case EVENT_SENT:
+        if (target.getSentEvent() == null) {
+          target.setSentEvent(new WxMaSubscribeMsgEvent.SubscribeMsgSentEvent());
+        }
+        WxMaSubscribeMsgEvent.SentEvent sentEvent = new WxMaSubscribeMsgEvent.SentEvent();
+        sentEvent.setTemplateId(json.get("TemplateId").getAsString());
+        sentEvent.setMsgId(json.get("MsgID").getAsString());
+        sentEvent.setErrorCode(json.get("ErrorCode").getAsString());
+        sentEvent.setErrorStatus(json.get("ErrorStatus").getAsString());
+        target.getSentEvent().setList(sentEvent);
+        break;
+    }
+    return target;
+  }
+}

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/bean/WxMaMessageTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/bean/WxMaMessageTest.java
@@ -4,6 +4,7 @@ import me.chanjar.weixin.common.api.WxConsts;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 /**
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
@@ -45,6 +46,184 @@ public class WxMaMessageTest {
     assertEquals(wxMessage.getAppId(), "AppId");
     assertEquals(wxMessage.getEvent(), "user_enter_tempsession");
     assertEquals(wxMessage.getSessionFrom(), "sessionFrom");
+  }
+
+  public void testSubscribeMsgPopupEvent() {
+    // xml 格式
+    String xml = "<xml>" +
+      "<ToUserName><![CDATA[gh_123456789abc]]></ToUserName>\n" +
+      "<FromUserName><![CDATA[otFpruAK8D-E6EfStSYonYSBZ8_4]]></FromUserName>\n" +
+      "<CreateTime>1610969440</CreateTime>\n" +
+      "<MsgType><![CDATA[event]]></MsgType>\n" +
+      "<Event><![CDATA[subscribe_msg_popup_event]]></Event>\n" +
+      "<SubscribeMsgPopupEvent>\n" +
+      " <List>\n" +
+      "   <TemplateId><![CDATA[VRR0UEO9VJOLs0MHlU0OilqX6MVFDwH3_3gz3Oc0NIc]]></TemplateId>\n" +
+      "   <SubscribeStatusString><![CDATA[accept]]></SubscribeStatusString>\n" +
+      "   <PopupScene>0</PopupScene>\n" +
+      " </List>\n" +
+      "</SubscribeMsgPopupEvent>" +
+      "</xml>";
+
+    WxMaMessage wxMessage = WxMaMessage.fromXml(xml);
+    checkSubscribeMsgPopupEvent(wxMessage);
+
+    // 订阅单个模板  json格式 (对象）
+    String json = "{\n" +
+      "  \"ToUserName\": \"gh_123456789abc\",\n" +
+      "  \"FromUserName\": \"otFpruAK8D-E6EfStSYonYSBZ8_4\",\n" +
+      "  \"CreateTime\": \"1610969440\",\n" +
+      "  \"MsgType\": \"event\",\n" +
+      "  \"Event\": \"subscribe_msg_popup_event\",\n" +
+      "  \"List\": {\n" +
+      "        \"TemplateId\": \"VRR0UEO9VJOLs0MHlU0OilqX6MVFDwH3_3gz3Oc0NIc\",\n" +
+      "        \"SubscribeStatusString\": \"accept\",\n" +
+      "        \"PopupScene\": \"0\"\n" +
+      "    }\n" +
+      " }";
+    wxMessage = WxMaMessage.fromJson(json);
+    checkSubscribeMsgPopupEvent(wxMessage);
+    // 订阅多条模板的  json格式（数组）
+    json = "{\n" +
+      "  \"ToUserName\": \"gh_123456789abc\",\n" +
+      "  \"FromUserName\": \"otFpruAK8D-E6EfStSYonYSBZ8_4\",\n" +
+      "  \"CreateTime\": \"1610969440\",\n" +
+      "  \"MsgType\": \"event\",\n" +
+      "  \"Event\": \"subscribe_msg_popup_event\",\n" +
+      "  \"List\": [{\n" +
+      "        \"TemplateId\": \"VRR0UEO9VJOLs0MHlU0OilqX6MVFDwH3_3gz3Oc0NIc\",\n" +
+      "        \"SubscribeStatusString\": \"accept\",\n" +
+      "        \"PopupScene\": \"0\"\n" +
+      "    }]\n" +
+      " }";
+    wxMessage = WxMaMessage.fromJson(json);
+    checkSubscribeMsgPopupEvent(wxMessage);
+  }
+
+  private void checkSubscribeMsgPopupEvent(WxMaMessage wxMessage) {
+    assertEquals(wxMessage.getToUser(), "gh_123456789abc");
+    assertEquals(wxMessage.getFromUser(), "otFpruAK8D-E6EfStSYonYSBZ8_4");
+    assertEquals(wxMessage.getCreateTime(),new Integer(1610969440));
+    assertEquals(wxMessage.getMsgType(), WxConsts.XmlMsgType.EVENT);
+    assertEquals(wxMessage.getEvent(), "subscribe_msg_popup_event");
+    assertEquals(wxMessage.getSubscribeMsgPopupEvent().getList().size(), 1);
+    WxMaSubscribeMsgEvent.PopupEvent event = wxMessage.getSubscribeMsgPopupEvent().getList().get(0);
+    assertEquals(event.getTemplateId(), "VRR0UEO9VJOLs0MHlU0OilqX6MVFDwH3_3gz3Oc0NIc");
+    assertEquals(event.getSubscribeStatusString(),"accept");
+    assertEquals(event.getPopupScene(), "0");
+  }
+
+  public void testSubscribeMsgChangeEvent() {
+    // xml 格式
+    String xml = "<xml>\n" +
+      "    <ToUserName><![CDATA[gh_123456789abc]]></ToUserName>\n" +
+      "    <FromUserName><![CDATA[o7esq5OI1Uej6Xixw1lA2H7XDVbc]]></FromUserName>\n" +
+      "    <CreateTime>1610968440</CreateTime>\n" +
+      "    <MsgType><![CDATA[event]]></MsgType>\n" +
+      "    <Event><![CDATA[subscribe_msg_change_event]]></Event>\n" +
+      "    <SubscribeMsgChangeEvent>\n" +
+      "        <List>" +
+      "             <TemplateId><![CDATA[BEwX0BOT3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8]]></TemplateId>\n" +
+      "            <SubscribeStatusString><![CDATA[reject]]></SubscribeStatusString>\n" +
+      "        </List>\n" +
+      "    </SubscribeMsgChangeEvent>\n" +
+      "</xml>";
+
+    WxMaMessage wxMessage = WxMaMessage.fromXml(xml);
+    checkSubscribeMsgChangeEvent(wxMessage);
+
+    // json格式 (对象）
+    String json = "{\n" +
+      "      \"ToUserName\": \"gh_123456789abc\",\n" +
+      "      \"FromUserName\": \"o7esq5OI1Uej6Xixw1lA2H7XDVbc\",\n" +
+      "      \"CreateTime\": \"1610968440\",\n" +
+      "      \"MsgType\": \"event\",\n" +
+      "      \"Event\": \"subscribe_msg_change_event\",\n" +
+      "      \"List\": {\n" +
+      "                \"TemplateId\":\"BEwX0BOT3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8\",\n" +
+      "                \"SubscribeStatusString\": \"reject\"\n" +
+      "      }\n" +
+      "}\n";
+    wxMessage = WxMaMessage.fromJson(json);
+    checkSubscribeMsgChangeEvent(wxMessage);
+    // json格式（数组）
+    json = "{\n" +
+      "      \"ToUserName\": \"gh_123456789abc\",\n" +
+      "      \"FromUserName\": \"o7esq5OI1Uej6Xixw1lA2H7XDVbc\",\n" +
+      "      \"CreateTime\": \"1610968440\",\n" +
+      "      \"MsgType\": \"event\",\n" +
+      "      \"Event\": \"subscribe_msg_change_event\",\n" +
+      "      \"List\": [  {\n" +
+      "                \"TemplateId\":\"BEwX0BOT3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8\",\n" +
+      "                \"SubscribeStatusString\": \"reject\"\n" +
+      "      }]" +
+      "}";
+    wxMessage = WxMaMessage.fromJson(json);
+    checkSubscribeMsgChangeEvent(wxMessage);
+  }
+
+  private void checkSubscribeMsgChangeEvent(WxMaMessage wxMessage) {
+    assertEquals(wxMessage.getToUser(), "gh_123456789abc");
+    assertEquals(wxMessage.getFromUser(), "o7esq5OI1Uej6Xixw1lA2H7XDVbc");
+    assertEquals(wxMessage.getCreateTime(),new Integer(1610968440));
+    assertEquals(wxMessage.getMsgType(), WxConsts.XmlMsgType.EVENT);
+    assertEquals(wxMessage.getEvent(), "subscribe_msg_change_event");
+    assertEquals(wxMessage.getSubscribeMsgChangeEvent().getList().size(), 1);
+    WxMaSubscribeMsgEvent.ChangeEvent event = wxMessage.getSubscribeMsgChangeEvent().getList().get(0);
+    assertEquals(event.getTemplateId(), "BEwX0BOT3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8");
+    assertEquals(event.getSubscribeStatusString(),"reject");
+  }
+
+  public void testSubscribeMsgSentEvent() {
+    // xml 格式
+    String xml = "<xml>\n" +
+      "    <ToUserName><![CDATA[gh_123456789abc]]></ToUserName>\n" +
+      "    <FromUserName><![CDATA[o7esq5PHRGBQYmeNyfG064wEFVpQ]]></FromUserName>\n" +
+      "    <CreateTime>1620963428</CreateTime>\n" +
+      "    <MsgType><![CDATA[event]]></MsgType>\n" +
+      "    <Event><![CDATA[subscribe_msg_sent_event]]></Event>\n" +
+      "    <SubscribeMsgSentEvent>\n" +
+      "        <List>" +
+      "             <TemplateId><![CDATA[BEwX0BO-T3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8]]></TemplateId>\n" +
+      "            <MsgID>1864323726461255680</MsgID>\n" +
+      "            <ErrorCode>0</ErrorCode>\n" +
+      "            <ErrorStatus><![CDATA[success]]></ErrorStatus>\n" +
+      "        </List>\n" +
+      "    </SubscribeMsgSentEvent>\n" +
+      "</xml>";
+
+    WxMaMessage wxMessage = WxMaMessage.fromXml(xml);
+    checkSubscribeMsgSentEvent(wxMessage);
+
+    // json格式 (对象）
+    String json = "{\n" +
+      "    \"ToUserName\": \"gh_123456789abc\",\n" +
+      "    \"FromUserName\": \"o7esq5PHRGBQYmeNyfG064wEFVpQ\",\n" +
+      "    \"CreateTime\": \"1620963428\",\n" +
+      "    \"MsgType\": \"event\",\n" +
+      "    \"Event\": \"subscribe_msg_sent_event\",\n" +
+      "    \"List\": {\n" +
+      "        \"TemplateId\": \"BEwX0BO-T3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8\",\n" +
+      "        \"MsgID\": \"1864323726461255680\",\n" +
+      "        \"ErrorCode\": \"0\",\n" +
+      "        \"ErrorStatus\": \"success\"\n" +
+      "      }\n" +
+      "}";
+    wxMessage = WxMaMessage.fromJson(json);
+    checkSubscribeMsgSentEvent(wxMessage);
+  }
+  private void checkSubscribeMsgSentEvent(WxMaMessage wxMessage) {
+    assertEquals(wxMessage.getToUser(), "gh_123456789abc");
+    assertEquals(wxMessage.getFromUser(), "o7esq5PHRGBQYmeNyfG064wEFVpQ");
+    assertEquals(wxMessage.getCreateTime(),new Integer(1620963428));
+    assertEquals(wxMessage.getMsgType(), WxConsts.XmlMsgType.EVENT);
+    assertEquals(wxMessage.getEvent(), "subscribe_msg_sent_event");
+    assertNotNull(wxMessage.getSubscribeMsgSentEvent());
+    WxMaSubscribeMsgEvent.SentEvent event = wxMessage.getSubscribeMsgSentEvent().getList();
+    assertEquals(event.getTemplateId(), "BEwX0BO-T3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8");
+    assertEquals(event.getMsgId(),"1864323726461255680");
+    assertEquals(event.getErrorCode(),"0");
+    assertEquals(event.getErrorStatus(),"success");
   }
 
 }


### PR DESCRIPTION
小程序端订阅消息之后，服务器会收到3种通知SubscribeMsgPopupEvent，SubscribeMsgChangeEvent，SubscribeMsgSentEvent，这三种通知是xml格式层级正常，如果是json格式的，三种类型的通知都叫做List，并且通知如果只有一条数据则List是对象，如果是多条数据List是数组
一条数据的时候是这样的
`{
      "ToUserName": "gh_123456789abc",
      "FromUserName": "o7esq5OI1Uej6Xixw1lA2H7XDVbc",
      "CreateTime": "1610968440",
      "MsgType": "event",
      "Event": "subscribe_msg_change_event",
      "List": {
                "TemplateId":"BEwX0BOT3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8",
                "SubscribeStatusString": "reject"
      }
}
`
多条数据的时候是这样的
`{
      "ToUserName": "gh_123456789abc",
      "FromUserName": "o7esq5OI1Uej6Xixw1lA2H7XDVbc",
      "CreateTime": "1610968440",
      "MsgType": "event",
      "Event": "subscribe_msg_change_event",
      "List": [  {
                "TemplateId":"BEwX0BOT3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8",
                "SubscribeStatusString": "reject"
      }，{
                "TemplateId":"BEwX0BOT3MqK3Uc5oTU3CGBqzjpndk2jzUf7VfExd8",
                "SubscribeStatusString": "reject"
      }]
}
`
在代码里面对这种情况做了兼容