### PR TITLE
补充wxMaService.getInternetService().getUserEncryptKey()接口参数

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaInternetService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaInternetService.java
@@ -8,20 +8,36 @@ import me.chanjar.weixin.common.error.WxErrorException;
  * 【小程序-服务端-网络】网络相关接口.
  *  文档地址：https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/internet/internet.getUserEncryptKey.html
  * </pre>
+ *
  * @author <a href="https://github.com/chutian0124">chutian0124</a>
  */
 public interface WxMaInternetService {
   /**
-   *
-   *
    * <pre>
    * 获取用户encryptKey。 会获取用户最近3次的key，每个key的存活时间为3600s。
    * 文档地址：https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/internet/internet.getUserEncryptKey.html
    * 接口地址：POST https://api.weixin.qq.com/wxa/business/getuserencryptkey?access_token=ACCESS_TOKEN&openid=OPENID&signature=SIGNATURE&sig_method=hmac_sha256
+   * @param openid 用户的openid
+   * @param signature 用sessionkey对空字符串签名得到的结果
+   * @param sigMethod 签名方法，只支持 hmac_sha256
    * </pre>
    *
    * @return {@link WxMaInternetResponse}
    * @throws WxErrorException
    */
-  WxMaInternetResponse getUserEncryptKey() throws WxErrorException;
+  WxMaInternetResponse getUserEncryptKey(String openid, String signature, String sigMethod) throws WxErrorException;
+
+  /**
+   * <pre>
+   * 获取用户encryptKey。 会获取用户最近3次的key，每个key的存活时间为3600s。
+   * 文档地址：https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/internet/internet.getUserEncryptKey.html
+   * 接口地址：POST https://api.weixin.qq.com/wxa/business/getuserencryptkey?access_token=ACCESS_TOKEN&openid=OPENID&signature=SIGNATURE&sig_method=hmac_sha256
+   * @param openid 用户的openid
+   * @param sessionKey 用户的sessionKey
+   * </pre>
+   *
+   * @return {@link WxMaInternetResponse}
+   * @throws WxErrorException
+   */
+  WxMaInternetResponse getUserEncryptKey(String openid, String sessionKey) throws WxErrorException;
 }

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaInternetServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaInternetServiceImpl.java
@@ -9,9 +9,12 @@ import lombok.RequiredArgsConstructor;
 import me.chanjar.weixin.common.enums.WxType;
 import me.chanjar.weixin.common.error.WxError;
 import me.chanjar.weixin.common.error.WxErrorException;
+import org.jetbrains.annotations.NotNull;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
- *
  * 服务端网络相关接口
  *
  * @author <a href="https://github.com/chutian0124">chutian0124</a>
@@ -21,9 +24,39 @@ import me.chanjar.weixin.common.error.WxErrorException;
 public class WxMaInternetServiceImpl implements WxMaInternetService {
   private final WxMaService wxMaService;
 
+  private String sha256(String data, String sessionKey) throws Exception {
+    Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
+    SecretKeySpec secret_key = new SecretKeySpec(sessionKey.getBytes("UTF-8"), "HmacSHA256");
+    sha256_HMAC.init(secret_key);
+    byte[] array = sha256_HMAC.doFinal(data.getBytes("UTF-8"));
+    StringBuilder sb = new StringBuilder();
+    for (byte item : array) {
+      sb.append(Integer.toHexString((item & 0xFF) | 0x100).substring(1, 3));
+    }
+    return sb.toString().toUpperCase();
+  }
+
   @Override
-  public WxMaInternetResponse getUserEncryptKey() throws WxErrorException {
-    String responseContent = this.wxMaService.post(WxMaApiUrlConstants.Internet.GET_USER_ENCRYPT_KEY, "");
+  public WxMaInternetResponse getUserEncryptKey(String openid, String signature, String sigMethod) throws WxErrorException {
+    String url = WxMaApiUrlConstants.Internet.GET_USER_ENCRYPT_KEY + "?openid=" + openid + "&signature=" + signature + "&sig_method=" + sigMethod;
+    return getWxMaInternetResponse(url);
+  }
+
+  @Override
+  public WxMaInternetResponse getUserEncryptKey(String openid, String sessionKey) throws WxErrorException {
+    String signature = null;
+    try {
+      signature = sha256("", sessionKey);
+    } catch (Exception e) {
+      throw new WxErrorException("签名错误");
+    }
+    String url = WxMaApiUrlConstants.Internet.GET_USER_ENCRYPT_KEY + "?sig_method=hmac_sha256&openid=" + openid + "&signature=" + signature;
+    return getWxMaInternetResponse(url);
+  }
+
+  @NotNull
+  private WxMaInternetResponse getWxMaInternetResponse(String url) throws WxErrorException {
+    String responseContent = this.wxMaService.post(url, "");
     WxMaInternetResponse response = WxMaGsonBuilder.create().fromJson(responseContent, WxMaInternetResponse.class);
     if (response.getErrcode() == -1) {
       throw new WxErrorException(WxError.fromJson(responseContent, WxType.MiniApp));

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaInternetServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaInternetServiceImplTest.java
@@ -4,12 +4,15 @@ import cn.binarywang.wx.miniapp.api.WxMaService;
 import cn.binarywang.wx.miniapp.bean.internet.WxMaInternetResponse;
 import cn.binarywang.wx.miniapp.test.ApiTestModule;
 import com.google.inject.Inject;
-import me.chanjar.weixin.common.error.WxErrorException;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
- *
  * 服务端网络相关接口测试
  *
  * @author <a href="https://github.com/chutian0124">chutian0124</a>
@@ -21,9 +24,32 @@ public class WxMaInternetServiceImplTest {
   @Inject
   private WxMaService wxService;
 
+  private static String HMACSHA256(String data, String key) throws Exception {
+    Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
+    SecretKeySpec secret_key = new SecretKeySpec(key.getBytes("UTF-8"), "HmacSHA256");
+    sha256_HMAC.init(secret_key);
+    byte[] array = sha256_HMAC.doFinal(data.getBytes("UTF-8"));
+    StringBuilder sb = new StringBuilder();
+    for (byte item : array) {
+      sb.append(Integer.toHexString((item & 0xFF) | 0x100).substring(1, 3));
+    }
+    return sb.toString().toUpperCase();
+  }
+
   @Test
-  public void testGetUserEncryptKey() throws WxErrorException {
-    WxMaInternetResponse response = this.wxService.getInternetService().getUserEncryptKey();
-    System.out.println(response);
+  public void testGetUserEncryptKey() throws Exception {
+    String openid = "ogu-84hVFTbTt-myGisQESoDJ6BM";
+    String signature = HMACSHA256("", "9ny8n3t0KULoi0deF7T9pw==");
+    String sigMethod = "hmac_sha256";
+    WxMaInternetResponse response = this.wxService.getInternetService().getUserEncryptKey(openid, signature, sigMethod);
+    assertThat(response).isNotNull();
+  }
+
+  @Test
+  public void testGetUserEncryptKey2() throws Exception {
+    String openid = "ogu-84hVFTbTt-myGisQESoDJ6BM";
+    String sessionKey = "9ny8n3t0KULoi0deF7T9pw==";
+    WxMaInternetResponse response = this.wxService.getInternetService().getUserEncryptKey(openid, sessionKey);
+    assertThat(response).isNotNull();
   }
 }

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImplTest.java
@@ -76,4 +76,9 @@ public class WxMaUserServiceImplTest {
   public void testGetNewPhoneNoInfo() throws Exception{
     assertNotNull(wxService.getUserService().getNewPhoneNoInfo("test"));
   }
+
+  @Test
+  public void testGetAccessToken() throws Exception{
+    assertNotNull(wxService.getAccessToken(true));
+  }
 }


### PR DESCRIPTION
https://developers.weixin.qq.com/minigame/dev/api-backend/open-api/internet/internet.getUserEncryptKey.html
<h3 id="请求参数" style="margin: 2em 0px 0.5em; padding: 0px; -webkit-tap-highlight-color: transparent; font-family: &quot;PingFang SC&quot;; font-weight: 600; color: rgb(0, 0, 0); font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">请求参数</h3><div class="table-wrp" style="margin: 1em 0px 3em; padding: 0px; -webkit-tap-highlight-color: transparent; overflow-x: auto; max-width: 100%; color: rgb(34, 34, 34); font-family: -apple-system, &quot;system-ui&quot;, &quot;SF UI Text&quot;, &quot;Helvetica Neue&quot;, &quot;PingFang SC&quot;, &quot;Hiragino Sans GB&quot;, &quot;Microsoft YaHei UI&quot;, &quot;Microsoft YaHei&quot;, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

属性 | 类型 | 默认值 | 必填 | 说明
-- | -- | -- | -- | --
access_token / cloudbase_access_token | string |   | 是 | 接口调用凭证
openid | string |   | 是 | 用户的openid
signature | string |   | 是 | 用sessionkey对空字符串签名得到的结果
sig_method | string |   | 是 | 签名方法，只支持 hmac_sha256

</div>