### PR TITLE
fix(公众号):修复WxMenu序列化artical_id

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/WxMenuGsonAdapter.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/WxMenuGsonAdapter.java
@@ -46,6 +46,7 @@ public class WxMenuGsonAdapter implements JsonSerializer<WxMenu>, JsonDeserializ
     buttonJson.addProperty("key", button.getKey());
     buttonJson.addProperty("url", button.getUrl());
     buttonJson.addProperty("media_id", button.getMediaId());
+    buttonJson.addProperty("article_id", button.getArticleId());
     buttonJson.addProperty("appid", button.getAppId());
     buttonJson.addProperty("pagepath", button.getPagePath());
     if (button.getSubButtons() != null && button.getSubButtons().size() > 0) {
@@ -122,6 +123,7 @@ public class WxMenuGsonAdapter implements JsonSerializer<WxMenu>, JsonDeserializ
     button.setUrl(GsonHelper.getString(json, "url"));
     button.setType(GsonHelper.getString(json, "type"));
     button.setMediaId(GsonHelper.getString(json, "media_id"));
+    button.setArticleId(GsonHelper.getString(json, "article_id"));
     button.setAppId(GsonHelper.getString(json, "appid"));
     button.setPagePath(GsonHelper.getString(json, "pagepath"));
     return button;


### PR DESCRIPTION
创建公众号菜单时，之前没有序列化article_id，导致无法新增文章类型的按钮。