### PR TITLE
【微信小程序】小程序直播挂件组件商品添加并提审接口新增字段goodsKey

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/live/WxMaLiveGoodInfo.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/live/WxMaLiveGoodInfo.java
@@ -4,6 +4,7 @@ import lombok.Data;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * 直播商品信息
@@ -22,4 +23,8 @@ public class WxMaLiveGoodInfo implements Serializable {
    * 1, 2：表示是为api添加商品，否则是在MP添加商品
    */
   private String thirdPartyTag;
+  /**
+   * https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/industry/liveplayer/pendant.html
+   */
+  private List<String> goodsKey;
 }


### PR DESCRIPTION
https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/industry/liveplayer/pendant.html#%E5%9B%9B%E3%80%81%E6%8C%82%E4%BB%B6api%E6%8E%A5%E5%8F%A3

为了支持有规律同类型页面中增加挂件组件，微信官方文档指出原商品添加并提审接口应提交goodsKey字段。