### PR TITLE
在企业微信中获取审批单详情中控件的实体类中添加date_range解决当返回控件类型为date_range时无法获取到对应的数据，添加了外部联系人聊天敏感词的的新增、修改、删除的接口方法

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
@@ -961,27 +961,38 @@ public interface WxCpExternalContactService {
     throws WxErrorException;
 
   /**
+   * <pre>
    * 新建敏感词规则
    * 企业和第三方应用可以通过此接口新建敏感词规则
    * 请求方式：POST(HTTPS)
    * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/add_intercept_rule?access_token=ACCESS_TOKEN
+   * <pre>
    * @param ruleResp
+   * @return WxCpInterceptRuleResultResp
+   * @throws WxErrorException
    */
   WxCpInterceptRuleResultResp addInterceptRule(WxCpInterceptRuleResp ruleResp) throws  WxErrorException;
   /**
+   * <pre>
    * 修改敏感词规则
    * 企业和第三方应用可以通过此接口修改敏感词规则
    * 请求方式：POST(HTTPS)
    * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/update_intercept_rule?access_token=ACCESS_TOKEN
+   * <pre>
    * @param ruleResp
+   * @return WxCpInterceptRuleResultResp
+   * @throws WxErrorException
    */
   WxCpInterceptRuleResultResp updateInterceptRule(WxCpInterceptRuleResp ruleResp) throws  WxErrorException;
   /**
+   * <pre>
    * 删除敏感词规则
    * 企业和第三方应用可以通过此接口修改敏感词规则
    * 请求方式：POST(HTTPS)
    * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/del_intercept_rule?access_token=ACCESS_TOKEN
+   * <pre>
    * @param rule_id 规则id
+   * @return WxCpBaseResp
    * @throws WxErrorException
    */
   WxCpBaseResp delInterceptRule(String rule_id) throws  WxErrorException;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
@@ -967,9 +967,6 @@ public interface WxCpExternalContactService {
    * 请求方式：POST(HTTPS)
    * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/add_intercept_rule?access_token=ACCESS_TOKEN
    * <pre>
-   * @param ruleResp
-   * @return WxCpInterceptRuleResultResp
-   * @throws WxErrorException
    */
   WxCpInterceptRuleResultResp addInterceptRule(WxCpInterceptRuleResp ruleResp) throws  WxErrorException;
   /**
@@ -979,9 +976,6 @@ public interface WxCpExternalContactService {
    * 请求方式：POST(HTTPS)
    * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/update_intercept_rule?access_token=ACCESS_TOKEN
    * <pre>
-   * @param ruleResp
-   * @return WxCpInterceptRuleResultResp
-   * @throws WxErrorException
    */
   WxCpInterceptRuleResultResp updateInterceptRule(WxCpInterceptRuleResp ruleResp) throws  WxErrorException;
   /**
@@ -992,8 +986,6 @@ public interface WxCpExternalContactService {
    * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/del_intercept_rule?access_token=ACCESS_TOKEN
    * <pre>
    * @param rule_id 规则id
-   * @return WxCpBaseResp
-   * @throws WxErrorException
    */
   WxCpBaseResp delInterceptRule(String rule_id) throws  WxErrorException;
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
@@ -960,5 +960,30 @@ public interface WxCpExternalContactService {
   WxMediaUploadResult uploadAttachment(String mediaType, Integer attachmentType, File file)
     throws WxErrorException;
 
+  /**
+   * 新建敏感词规则
+   * 企业和第三方应用可以通过此接口新建敏感词规则
+   * 请求方式：POST(HTTPS)
+   * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/add_intercept_rule?access_token=ACCESS_TOKEN
+   * @param ruleResp
+   */
+  WxCpInterceptRuleResultResp addInterceptRule(WxCpInterceptRuleResp ruleResp) throws  WxErrorException;
+  /**
+   * 修改敏感词规则
+   * 企业和第三方应用可以通过此接口修改敏感词规则
+   * 请求方式：POST(HTTPS)
+   * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/update_intercept_rule?access_token=ACCESS_TOKEN
+   * @param ruleResp
+   */
+  WxCpInterceptRuleResultResp updateInterceptRule(WxCpInterceptRuleResp ruleResp) throws  WxErrorException;
+  /**
+   * 删除敏感词规则
+   * 企业和第三方应用可以通过此接口修改敏感词规则
+   * 请求方式：POST(HTTPS)
+   * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/externalcontact/del_intercept_rule?access_token=ACCESS_TOKEN
+   * @param rule_id 规则id
+   * @throws WxErrorException
+   */
+  WxCpBaseResp delInterceptRule(String rule_id) throws  WxErrorException;
 
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpExternalContactServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpExternalContactServiceImpl.java
@@ -845,7 +845,7 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
   @Override
   public WxCpInterceptRuleResultResp addInterceptRule(WxCpInterceptRuleResp ruleResp) throws WxErrorException {
     return WxCpInterceptRuleResultResp
-      .fromJson(this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(UPDATE_INTERCEPT_RULE), ruleResp.toJson()));
+      .fromJson(this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(ADD_INTERCEPT_RULE), ruleResp.toJson()));
   }
 
   @Override
@@ -859,7 +859,7 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("rule_id",rule_id);
     return WxCpBaseResp
-      .fromJson(this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(UPDATE_INTERCEPT_RULE), jsonObject));
+      .fromJson(this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(DEL_INTERCEPT_RULE), jsonObject));
   }
 
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpExternalContactServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpExternalContactServiceImpl.java
@@ -2,10 +2,12 @@ package me.chanjar.weixin.cp.api.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
@@ -111,7 +113,7 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
   @Override
   public WxCpExternalContactInfo getContactDetail(String userId, String cursor) throws WxErrorException {
     String params = userId;
-    if(StringUtils.isNotEmpty(cursor)){
+    if (StringUtils.isNotEmpty(cursor)) {
       params = params + "&cursor=" + cursor;
     }
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(GET_CONTACT_DETAIL + params);
@@ -130,11 +132,11 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
   }
 
   @Override
-  public String unionidToExternalUserid(@NotNull String unionid,String openid) throws WxErrorException {
+  public String unionidToExternalUserid(@NotNull String unionid, String openid) throws WxErrorException {
     JsonObject json = new JsonObject();
     json.addProperty("unionid", unionid);
-    if(StringUtils.isNotEmpty(openid)){
-      json.addProperty("openid",openid);
+    if (StringUtils.isNotEmpty(openid)) {
+      json.addProperty("openid", openid);
     }
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(UNIONID_TO_EXTERNAL_USERID);
     String responseContent = this.mainService.post(url, json.toString());
@@ -157,8 +159,8 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
     JsonObject json = new JsonObject();
     json.addProperty("unionid", unionid);
     json.addProperty("openid", openid);
-    if(StringUtils.isNotEmpty(corpid)){
-      json.addProperty("corpid",corpid);
+    if (StringUtils.isNotEmpty(corpid)) {
+      json.addProperty("corpid", corpid);
     }
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(UNIONID_TO_EXTERNAL_USERID_3RD);
     String responseContent = this.mainService.post(url, json.toString());
@@ -188,7 +190,7 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
   @Override
   public String opengidToChatid(@NotNull String opengid) throws WxErrorException {
     JsonObject json = new JsonObject();
-    json.addProperty("opengid",opengid);
+    json.addProperty("opengid", opengid);
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(OPENID_TO_CHATID);
     String responseContent = this.mainService.post(url, json.toString());
     JsonObject tmpJson = GsonParser.parse(responseContent);
@@ -247,7 +249,7 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
   @Override
   public WxCpUserExternalUnassignList listUnassignedList(Integer pageIndex, String cursor, Integer pageSize) throws WxErrorException {
     JsonObject json = new JsonObject();
-    if(pageIndex != null){
+    if (pageIndex != null) {
       json.addProperty("page_id", pageIndex);
     }
     json.addProperty("cursor", StringUtils.isEmpty(cursor) ? "" : cursor);
@@ -518,20 +520,20 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
 
   @Override
   public WxCpGetMomentList getMomentList(Long startTime, Long endTime, String creator, Integer filterType,
-    String cursor, Integer limit) throws WxErrorException {
+                                         String cursor, Integer limit) throws WxErrorException {
     JsonObject json = new JsonObject();
     json.addProperty("start_time", startTime);
     json.addProperty("end_time", endTime);
     if (!StringUtils.isEmpty(creator)) {
       json.addProperty("creator", creator);
     }
-    if (filterType!=null) {
+    if (filterType != null) {
       json.addProperty("filter_type", filterType);
     }
     if (!StringUtils.isEmpty(cursor)) {
       json.addProperty("cursor", cursor);
     }
-    if (limit!=null) {
+    if (limit != null) {
       json.addProperty("limit", limit);
     }
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(GET_MOMENT_LIST);
@@ -547,7 +549,7 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
     if (!StringUtils.isEmpty(cursor)) {
       json.addProperty("cursor", cursor);
     }
-    if (limit!=null) {
+    if (limit != null) {
       json.addProperty("limit", limit);
     }
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(GET_MOMENT_TASK);
@@ -557,14 +559,14 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
 
   @Override
   public WxCpGetMomentCustomerList getMomentCustomerList(String momentId, String userId,
-    String cursor, Integer limit) throws WxErrorException {
+                                                         String cursor, Integer limit) throws WxErrorException {
     JsonObject json = new JsonObject();
     json.addProperty("moment_id", momentId);
     json.addProperty("userid", userId);
     if (!StringUtils.isEmpty(cursor)) {
       json.addProperty("cursor", cursor);
     }
-    if (limit!=null) {
+    if (limit != null) {
       json.addProperty("limit", limit);
     }
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(GET_MOMENT_CUSTOMER_LIST);
@@ -574,14 +576,14 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
 
   @Override
   public WxCpGetMomentSendResult getMomentSendResult(String momentId, String userId,
-    String cursor, Integer limit) throws WxErrorException {
+                                                     String cursor, Integer limit) throws WxErrorException {
     JsonObject json = new JsonObject();
     json.addProperty("moment_id", momentId);
     json.addProperty("userid", userId);
     if (!StringUtils.isEmpty(cursor)) {
       json.addProperty("cursor", cursor);
     }
-    if (limit!=null) {
+    if (limit != null) {
       json.addProperty("limit", limit);
     }
     final String url = this.mainService.getWxCpConfigStorage().getApiUrl(GET_MOMENT_SEND_RESULT);
@@ -790,8 +792,8 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
    * https://work.weixin.qq.com/api/doc/90000/90135/95096#获取商品图册列表
    * </pre>
    *
-   * @param limit   返回的最大记录数，整型，最大值100，默认值50，超过最大值时取默认值
-   * @param cursor  用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
+   * @param limit  返回的最大记录数，整型，最大值100，默认值50，超过最大值时取默认值
+   * @param cursor 用于分页查询的游标，字符串类型，由上一次调用返回，首次调用可不填
    * @return wx cp base resp
    * @throws WxErrorException the wx error exception
    */
@@ -811,7 +813,7 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
    * https://work.weixin.qq.com/api/doc/90000/90135/95096#获取商品图册
    * </pre>
    *
-   * @param productId  商品id
+   * @param productId 商品id
    * @return wx cp base resp
    * @throws WxErrorException the wx error exception
    */
@@ -826,7 +828,7 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
 
   @Override
   public WxMediaUploadResult uploadAttachment(String mediaType, String fileType, Integer attachmentType,
-    InputStream inputStream) throws WxErrorException, IOException {
+                                              InputStream inputStream) throws WxErrorException, IOException {
     return uploadAttachment(mediaType, attachmentType, FileUtils.createTmpFile(inputStream,
       UUID.randomUUID().toString(), fileType));
   }
@@ -839,4 +841,26 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
     return this.mainService.execute(MediaUploadRequestExecutor.create(
       this.mainService.getRequestHttp()), url, file);
   }
+
+  @Override
+  public WxCpInterceptRuleResultResp addInterceptRule(WxCpInterceptRuleResp ruleResp) throws WxErrorException {
+    return WxCpInterceptRuleResultResp
+      .fromJson(this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(UPDATE_INTERCEPT_RULE), ruleResp.toJson()));
+  }
+
+  @Override
+  public WxCpInterceptRuleResultResp updateInterceptRule(WxCpInterceptRuleResp ruleResp) throws WxErrorException {
+    return WxCpInterceptRuleResultResp
+      .fromJson(this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(UPDATE_INTERCEPT_RULE), ruleResp.toJson()));
+  }
+
+  @Override
+  public WxCpBaseResp delInterceptRule(String rule_id) throws WxErrorException {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("rule_id",rule_id);
+    return WxCpBaseResp
+      .fromJson(this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(UPDATE_INTERCEPT_RULE), jsonObject));
+  }
+
+
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpInterceptRuleResp.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpInterceptRuleResp.java
@@ -1,0 +1,58 @@
+package me.chanjar.weixin.cp.bean.external;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * 新增敏感词规则请求参数封装实体类
+ *
+ * @author didi
+ * @date 2022-04-17
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WxCpInterceptRuleResp {
+  @SerializedName("rule_name")
+  private String ruleName;
+  @SerializedName("word_list")
+  private List<String> wordList;
+  @SerializedName("semantics_list")
+  private List<Integer> semanticsList;
+  @SerializedName("intercept_type")
+  private int interceptType;
+  @SerializedName("applicable_range")
+  private ApplicableRange applicableRange;
+
+  @Data
+  public static class ApplicableRange {
+    @SerializedName("user_list")
+    private List<String> userList;
+    @SerializedName("department_list")
+    private List<Integer> departmentList;
+    public static ApplicableRange fromJson(String json) {
+      return WxCpGsonBuilder.create().fromJson(json, ApplicableRange.class);
+    }
+
+    public String toJson() {
+      return WxCpGsonBuilder.create().toJson(this);
+    }
+  }
+
+  public static WxCpInterceptRuleResp fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpInterceptRuleResp.class);
+  }
+
+  public String toJson() {
+    return WxCpGsonBuilder.create().toJson(this);
+  }
+
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpInterceptRuleResp.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpInterceptRuleResp.java
@@ -21,8 +21,11 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class WxCpInterceptRuleResp {
+
   @SerializedName("rule_name")
   private String ruleName;
+  @SerializedName("rule_id")
+  private String ruleId;
   @SerializedName("word_list")
   private List<String> wordList;
   @SerializedName("semantics_list")

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpInterceptRuleResultResp.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpInterceptRuleResultResp.java
@@ -1,0 +1,30 @@
+package me.chanjar.weixin.cp.bean.external;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.io.Serializable;
+
+/**
+ * 新建敏感词规则负返回结果
+ * @author didi
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WxCpInterceptRuleResultResp  extends WxCpBaseResp implements Serializable {
+
+  @SerializedName("rule_id")
+  private  String ruleId;
+
+  public static WxCpInterceptRuleResultResp fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpInterceptRuleResultResp.class);
+  }
+
+  public String toJson() {
+    return WxCpGsonBuilder.create().toJson(this);
+  }
+
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/applydata/ContentValue.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/applydata/ContentValue.java
@@ -42,6 +42,9 @@ public class ContentValue implements Serializable {
 
   private Vacation vacation;
 
+  @SerializedName("date_range")
+  private Attendance.DataRange dateRange;
+
   @Data
   public static class Date implements Serializable {
     private static final long serialVersionUID = -6181554080062231138L;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -284,6 +284,7 @@ public interface WxCpApiPathConsts {
 
     String ADD_INTERCEPT_RULE = "/cgi-bin/externalcontact/add_intercept_rule";
     String UPDATE_INTERCEPT_RULE = "/cgi-bin/externalcontact/update_intercept_rule";
+    String DEL_INTERCEPT_RULE = "/cgi-bin/externalcontact/del_intercept_rule";
 
   }
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -281,6 +281,10 @@ public interface WxCpApiPathConsts {
 
     String UPLOAD_ATTACHMENT = "/cgi-bin/media/upload_attachment";
 
+
+    String ADD_INTERCEPT_RULE = "/cgi-bin/externalcontact/add_intercept_rule";
+    String UPDATE_INTERCEPT_RULE = "/cgi-bin/externalcontact/update_intercept_rule";
+
   }
 
   interface Kf {


### PR DESCRIPTION
企业微信的获取审批单详情中对于申请数据中类型为date_range的控件添加了对应的字段进行序列化