### PR TITLE
#2599 weixin-java-pay修复微信预代扣通知参数问题

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPreWithholdRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPreWithholdRequest.java
@@ -28,7 +28,7 @@ public class WxPreWithholdRequest implements Serializable {
    * 委托代扣协议ID
    */
   @SerializedName(value = "contract_id")
-  private String contractId;
+  private transient String contractId;
 
   /**
    * 直连商户号


### PR DESCRIPTION
微信签约代扣的预扣费通知接口url中包含了contract_id后再将改参数传入body中报错。