### PR TITLE
增加企业微信应用市场付费部分接口支持

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpAuthInfo.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpAuthInfo.java
@@ -36,6 +36,13 @@ public class WxCpTpAuthInfo extends WxCpBaseResp {
   @SerializedName("auth_info")
   private AuthInfo authInfo;
 
+
+  /**
+   * 企业当前生效的版本信息
+   */
+  @SerializedName("edition_info")
+  private EditionInfo editionInfo;
+
   @Getter
   @Setter
   public static class DealerCorpInfo extends WxCpBaseResp {
@@ -128,6 +135,22 @@ public class WxCpTpAuthInfo extends WxCpBaseResp {
 
   }
 
+  /**
+   * 企业当前生效的版本信息
+   */
+  @Getter
+  @Setter
+  public static class EditionInfo implements Serializable {
+    private static final long serialVersionUID = -5028321625140879571L;
+
+    /**
+     * 授权的应用信息，注意是一个数组，但仅旧的多应用套件授权时会返回多个agent，对新的单应用授权，永远只返回一个agent
+     */
+    @SerializedName("agent")
+    private List<Agent> agents;
+
+  }
+
   @Getter
   @Setter
   public static class Agent implements Serializable {
@@ -169,6 +192,57 @@ public class WxCpTpAuthInfo extends WxCpBaseResp {
      */
     @SerializedName("privilege")
     private Privilege privilege;
+
+    /**
+     * 版本id
+     */
+    @SerializedName("edition_id")
+    private String editionId;
+
+    /**
+     * 版本名称
+     */
+    @SerializedName("edition_name")
+    private String editionName;
+
+    /**
+     * 付费状态
+     * <br/>
+     * <ul>
+     *   <li>0-没有付费;</li>
+     *   <li>1-限时试用;</li>
+     *   <li>2-试用过期;</li>
+     *   <li>3-购买期内;</li>
+     *   <li>4-购买过期;</li>
+     *   <li>5-不限时试用;</li>
+     *   <li>6-购买期内，但是人数超标, 注意，超标后还可以用7天;</li>
+     *   <li>7-购买期内，但是人数超标, 且已经超标试用7天</li>
+     * </ul>
+     */
+    @SerializedName("app_status")
+    private Integer appStatus;
+
+    /**
+     * 用户上限。
+     * <p>特别注意, 以下情况该字段无意义，可以忽略：</p>
+     * <ul>
+     *   <li>1. 固定总价购买</li>
+     *   <li>2. app_status = 限时试用/试用过期/不限时试用</li>
+     *   <li>3. 在第2条“app_status=不限时试用”的情况下，如果该应用的配置为“小企业无使用限制”，user_limit有效，且为限制的人数</li>
+     * </ul>
+     */
+    @SerializedName("user_limit")
+    private Integer userLimit;
+
+    /**
+     * 版本到期时间, 秒级时间戳, 根据需要自行乘以1000（根据购买版本，可能是试用到期时间或付费使用到期时间）。
+     * <p>特别注意，以下情况该字段无意义，可以忽略：</p>
+     * <ul>
+     *   <li>1. app_status = 不限时试用</li>
+     * </ul>
+     */
+    @SerializedName("expired_time")
+    private Long expiredTime;
 
   }
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpPermanentCodeInfo.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpPermanentCodeInfo.java
@@ -46,6 +46,11 @@ public class WxCpTpPermanentCodeInfo extends WxCpBaseResp {
   @SerializedName("auth_user_info")
   private AuthUserInfo authUserInfo;
 
+  /**
+   * 企业当前生效的版本信息
+   */
+  @SerializedName("edition_info")
+  private EditionInfo editionInfo;
 
   @Getter
   @Setter
@@ -127,6 +132,22 @@ public class WxCpTpPermanentCodeInfo extends WxCpBaseResp {
 
   }
 
+  /**
+   * 企业当前生效的版本信息
+   */
+  @Getter
+  @Setter
+  public static class EditionInfo implements Serializable {
+    private static final long serialVersionUID = -5028321625140879571L;
+
+    /**
+     * 授权的应用信息，注意是一个数组，但仅旧的多应用套件授权时会返回多个agent，对新的单应用授权，永远只返回一个agent
+     */
+    @SerializedName("agent")
+    private List<Agent> agents;
+
+  }
+
   @Getter
   @Setter
   public static class Agent implements Serializable {
@@ -169,6 +190,56 @@ public class WxCpTpPermanentCodeInfo extends WxCpBaseResp {
     @SerializedName("privilege")
     private Privilege privilege;
 
+    /**
+     * 版本id
+     */
+    @SerializedName("edition_id")
+    private String editionId;
+
+    /**
+     * 版本名称
+     */
+    @SerializedName("edition_name")
+    private String editionName;
+
+    /**
+     * 付费状态
+     * <br/>
+     * <ul>
+     *   <li>0-没有付费;</li>
+     *   <li>1-限时试用;</li>
+     *   <li>2-试用过期;</li>
+     *   <li>3-购买期内;</li>
+     *   <li>4-购买过期;</li>
+     *   <li>5-不限时试用;</li>
+     *   <li>6-购买期内，但是人数超标, 注意，超标后还可以用7天;</li>
+     *   <li>7-购买期内，但是人数超标, 且已经超标试用7天</li>
+     * </ul>
+     */
+    @SerializedName("app_status")
+    private Integer appStatus;
+
+    /**
+     * 用户上限。
+     * <p>特别注意, 以下情况该字段无意义，可以忽略：</p>
+     * <ul>
+     *   <li>1. 固定总价购买</li>
+     *   <li>2. app_status = 限时试用/试用过期/不限时试用</li>
+     *   <li>3. 在第2条“app_status=不限时试用”的情况下，如果该应用的配置为“小企业无使用限制”，user_limit有效，且为限制的人数</li>
+     * </ul>
+     */
+    @SerializedName("user_limit")
+    private Integer userLimit;
+
+    /**
+     * 版本到期时间, 秒级时间戳, 根据需要自行乘以1000（根据购买版本，可能是试用到期时间或付费使用到期时间）。
+     * <p>特别注意，以下情况该字段无意义，可以忽略：</p>
+     * <ul>
+     *   <li>1. app_status = 不限时试用</li>
+     * </ul>
+     */
+    @SerializedName("expired_time")
+    private Long expiredTime;
   }
 
   /**

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpTpXmlMessage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpTpXmlMessage.java
@@ -314,6 +314,26 @@ public class WxCpTpXmlMessage implements Serializable {
   @XStreamConverter(value = XStreamCDataConverter.class)
   private String taskId;
 
+  @XStreamAlias("PaidCorpId")
+  @XStreamConverter(value = XStreamCDataConverter.class)
+  private String paidCorpId;
+
+  @XStreamAlias("OrderId")
+  @XStreamConverter(value = XStreamCDataConverter.class)
+  private String orderId;
+
+  @XStreamAlias("OperatorId")
+  @XStreamConverter(value = XStreamCDataConverter.class)
+  private String operatorId;
+
+  @XStreamAlias("OldOrderId")
+  @XStreamConverter(value = XStreamCDataConverter.class)
+  private String oldOrderId;
+
+  @XStreamAlias("NewOrderId")
+  @XStreamConverter(value = XStreamCDataConverter.class)
+  private String newOrderId;
+
   @Data
   @XStreamAlias("ContactSync")
   public static class ContactSync implements Serializable {

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpTpConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpTpConsts.java
@@ -47,6 +47,31 @@ public class WxCpTpConsts {
      */
     public static final String CHANGE_EXTERNAL_CONTACT = "change_external_contact";
 
+    /**
+     * 下单成功通知
+     */
+    public static final String OPEN_ORDER = "open_order";
+
+    /**
+     * 改单通知
+     */
+    public static final String CHANGE_ORDER = "change_order";
+
+    /**
+     * 支付成功通知
+     */
+    public static final String PAY_FOR_APP_SUCCESS = "pay_for_app_success";
+
+    /**
+     * 退款通知
+     */
+    public static final String REFUND = "refund";
+
+    /**
+     * 付费版本变更通知
+     */
+    public static final String CHANGE_EDITION = "change_editon";
+
   }
 
 }

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/tp/service/impl/BaseWxCpTpServiceImplTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/tp/service/impl/BaseWxCpTpServiceImplTest.java
@@ -12,6 +12,9 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.List;
+import java.util.Objects;
+
 import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.Tp.GET_AUTH_INFO;
 import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.Tp.GET_PERMANENT_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -250,6 +253,28 @@ public class BaseWxCpTpServiceImplTest {
       "                \"appid\":5\n" +
       "            }\n" +
       "        ]\n" +
+      "    },\n" +
+      "    \"edition_info\":\n" +
+      "    {\n" +
+      "        \"agent\" :\n" +
+      "        [\n" +
+      "            {\n" +
+      "                \"agentid\":1,\n" +
+      "                \"edition_id\":\"RLS65535\",\n" +
+      "                \"edition_name\":\"协同版\",\n" +
+      "                \"app_status\":3,\n" +
+      "                \"user_limit\":200,\n" +
+      "                \"expired_time\":1541990791\n" +
+      "            },\n" +
+      "            {\n" +
+      "                \"agentid\":1,\n" +
+      "                \"edition_id\":\"RLS65535\",\n" +
+      "                \"edition_name\":\"协同版\",\n" +
+      "                \"app_status\":3,\n" +
+      "                \"user_limit\":200,\n" +
+      "                \"expired_time\":1541990791\n" +
+      "            }\n" +
+      "        ]\n" +
       "    }\n" +
       "}\n";
 
@@ -263,6 +288,14 @@ public class BaseWxCpTpServiceImplTest {
     Mockito.doReturn(returnJson).when(tpService).post(configStorage.getApiUrl(GET_AUTH_INFO), jsonObject.toString());
     WxCpTpAuthInfo authInfo = tpService.getAuthInfo(authCorpId, permanentCode);
     Assert.assertNotNull(authInfo.getAuthCorpInfo().getCorpId());
+
+    final WxCpTpAuthInfo.EditionInfo editionInfo = authInfo.getEditionInfo();
+    Assert.assertNotNull(editionInfo);
+
+    final List<WxCpTpAuthInfo.Agent> editionInfoAgents = editionInfo.getAgents();
+    Assert.assertTrue(Objects.nonNull(editionInfoAgents) && !editionInfoAgents.isEmpty());
+
+    Assert.assertNotNull(editionInfoAgents.get(0).getExpiredTime());
   }
 
   @Test

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/tp/service/impl/BaseWxCpTpServiceImplTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/tp/service/impl/BaseWxCpTpServiceImplTest.java
@@ -182,6 +182,28 @@ public class BaseWxCpTpServiceImplTest {
       "    \"userid\": \"yuanqixun\", \n" +
       "    \"name\": \"袁启勋\", \n" +
       "    \"avatar\": \"http://wework.qpic.cn/bizmail/ZYqy8EswiaFyPnk7gy7eiafoicz3TL35f4bAvCf2eSe6RVYSK7aPDFxcw/0\"\n" +
+      "  },\n" +
+      "  \"edition_info\":\n" +
+      "  {\n" +
+      "      \"agent\" :\n" +
+      "      [\n" +
+      "          {\n" +
+      "              \"agentid\":1,\n" +
+      "              \"edition_id\":\"RLS65535\",\n" +
+      "              \"edition_name\":\"协同版\",\n" +
+      "              \"app_status\":3,\n" +
+      "              \"user_limit\":200,\n" +
+      "              \"expired_time\":1541990791\n" +
+      "          },\n" +
+      "          {\n" +
+      "              \"agentid\":1,\n" +
+      "              \"edition_id\":\"RLS65535\",\n" +
+      "              \"edition_name\":\"协同版\",\n" +
+      "              \"app_status\":3,\n" +
+      "              \"user_limit\":200,\n" +
+      "              \"expired_time\":1541990791\n" +
+      "          }\n" +
+      "      ]\n" +
       "  }\n" +
       "}";
 
@@ -195,6 +217,15 @@ public class BaseWxCpTpServiceImplTest {
     assertThat(tpPermanentCodeInfo.getAuthInfo().getAgents().get(0).getAgentId()).isEqualTo(1000012);
     Assert.assertNotNull(tpPermanentCodeInfo.getAuthInfo().getAgents().get(0).getSquareLogoUrl());
     Assert.assertNotNull(tpPermanentCodeInfo.getAuthCorpInfo().getCorpSquareLogoUrl());
+
+    final WxCpTpPermanentCodeInfo.EditionInfo editionInfo = tpPermanentCodeInfo.getEditionInfo();
+    Assert.assertNotNull(editionInfo);
+
+    final List<WxCpTpPermanentCodeInfo.Agent> editionInfoAgents = editionInfo.getAgents();
+    Assert.assertTrue(Objects.nonNull(editionInfoAgents) && !editionInfoAgents.isEmpty());
+
+    Assert.assertNotNull(editionInfoAgents.get(0).getExpiredTime());
+
   }
 
   @Test


### PR DESCRIPTION
企业微信第三方应用开发上架到企业微信的应用市场时，需要对接市场付费接口
官网文档地址：https://developer.work.weixin.qq.com/document/15219

-【企业微信第三方应用API】获取企业授权信息增加企业当前生效的版本信息相关字段
-【企业微信第三方应用API】获取企业永久授权码信息增加企业当前生效的版本信息相关字段