### PR TITLE
weixin-java-pay模块 WxPayScoreResult实体新增openid字段

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/payscore/WxPayScoreResult.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/payscore/WxPayScoreResult.java
@@ -100,6 +100,8 @@ public class WxPayScoreResult implements Serializable {
   @SerializedName("authorization_success_time")
   private  String authorizationSuccessTime;
 
+  @SerializedName("openid")
+  private String openid;
 
   /**
    * 收款信息


### PR DESCRIPTION
[weixin-java-pay] 微信支付分 支付成功回调通知接口 resource字段解密后的实体 新增**openid**字段
[文档链接](https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter6_1_22.shtml)