### PR TITLE
fix: 修复财付通支付参数报签名错误

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/EcommerceServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/EcommerceServiceImpl.java
@@ -110,7 +110,8 @@ public class EcommerceServiceImpl implements EcommerceService {
   @Override
   public <T> T partnerTransactions(TradeTypeEnum tradeType, PartnerTransactionsRequest request) throws WxPayException {
     TransactionsResult result = this.partner(tradeType, request);
-    return result.getPayInfo(tradeType, request.getSpAppid(),
+    String appId = request.getSubAppid() != null ? request.getSubAppid() : request.getSpAppid();
+    return result.getPayInfo(tradeType, appId,
       request.getSpMchid(), payService.getConfig().getPrivateKey());
   }
 


### PR DESCRIPTION
https://pay.weixin.qq.com/wiki/doc/apiv3_partner/apis/chapter4_5_4.shtml

> 商户申请的小程序对应的appid，由微信支付生成，可在小程序后台查看。若下单时候传了sub_appid,须为sub_appid的值。

