### PR TITLE
新增 申请隐私接口

### DIFF
--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveServiceTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveServiceTest.java
@@ -9,12 +9,12 @@ import me.chanjar.weixin.cp.bean.oa.wedrive.*;
 import me.chanjar.weixin.cp.config.WxCpConfigStorage;
 import me.chanjar.weixin.cp.demo.WxCpDemoInMemoryConfigStorage;
 import org.testng.annotations.Test;
-import sun.misc.BASE64Encoder;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -140,7 +140,7 @@ public class WxCpOaWeDriveServiceTest {
     byte[] buffer = new byte[(int)file.length()];
     inputFile.read(buffer);
     inputFile.close();
-    String encodeBase64Content = new BASE64Encoder().encode(buffer);
+    String encodeBase64Content = Base64.getEncoder().encodeToString(buffer);
     fileUploadRequest.setFileBase64Content(encodeBase64Content);
 
     WxCpFileUpload fileUpload = cpService.getOaWeDriveService().fileUpload(fileUploadRequest);

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/WxMaCodeLineColor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/WxMaCodeLineColor.java
@@ -2,6 +2,7 @@ package cn.binarywang.wx.miniapp.bean;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * <pre>
@@ -12,6 +13,7 @@ import lombok.Data;
  * @author Element
  */
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class WxMaCodeLineColor {
   private String r = "0", g = "0", b = "0";

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenMaPrivacyService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenMaPrivacyService.java
@@ -1,14 +1,13 @@
 package me.chanjar.weixin.open.api;
 
 import me.chanjar.weixin.common.error.WxErrorException;
-import me.chanjar.weixin.open.bean.ma.privacy.GetPrivacySettingResult;
-import me.chanjar.weixin.open.bean.ma.privacy.SetPrivacySetting;
-import me.chanjar.weixin.open.bean.ma.privacy.UploadPrivacyFileResult;
+import me.chanjar.weixin.open.bean.ma.privacy.*;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * 微信第三方平台 小程序用户隐私保护指引接口
+ * 微信第三方平台 小程序用户隐私保护指引接口 / 申请隐私接口(从2022年4月18日开始，部分小程序前端 api 需申请后，方可使用。该接口用于获取“需申请并审核通过”后才可使用的接口列表。)
  * https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/privacy_config/set_privacy_setting.html
+ * https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/apply_api/get_privacy_interface.html
  *
  * @author <a href="https://www.sacoc.cn">广州跨界</a>
  */
@@ -28,6 +27,16 @@ public interface WxOpenMaPrivacyService {
    * 3 上传小程序用户隐私保护指引文件
    */
   String OPEN_UPLOAD_PRIVACY_FILE = "https://api.weixin.qq.com/cgi-bin/component/uploadprivacyextfile";
+
+  /**
+   * 4 获取接口列表 从2022年4月18日开始，部分小程序前端 api 需申请后
+   */
+  String GET_PRIVATE_INTERFACE = "https://api.weixin.qq.com/wxa/security/get_privacy_interface";
+
+  /**
+   * 5 申请接口 从2022年4月18日开始，部分小程序前端 api 需申请后
+   */
+  String APPLY_PRIVATE_INTERFACE = "https://api.weixin.qq.com/wxa/security/apply_privacy_interface";
 
 
   /**
@@ -62,4 +71,27 @@ public interface WxOpenMaPrivacyService {
    * @throws WxErrorException 如果出错,抛出此异常
    */
   UploadPrivacyFileResult uploadPrivacyFile(String content) throws WxErrorException;
+
+
+  /**
+   * 隐私接口-获取接口列表
+   * 从2022年4月18日开始，部分小程序前端 api 需申请后，方可使用。该接口用于获取“需申请并审核通过”后才可使用的接口列表。
+   * 文档地址:https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/apply_api/get_privacy_interface.html
+   *
+   * @return 获取结果
+   * @throws WxErrorException 如果出错,抛出此异常
+   */
+  GetPrivacyInterfaceResult getPrivacyInterface() throws WxErrorException;
+
+
+  /**
+   * 隐私接口-申请接口
+   * 从2022年4月18日开始，部分小程序前端 api 需申请后，方可使用。该接口用于获取“需申请并审核通过”后才可使用的接口列表。
+   * 文档地址:https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/apply_api/get_privacy_interface.html
+   *
+   * @param dto 请求参数
+   * @return 获取结果
+   * @throws WxErrorException 如果出错,抛出此异常
+   */
+  ApplyPrivacyInterfaceResult applyPrivacyInterface(ApplyPrivacyInterface dto) throws WxErrorException;
 }

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenMaPrivacyServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenMaPrivacyServiceImpl.java
@@ -6,9 +6,7 @@ import lombok.SneakyThrows;
 import me.chanjar.weixin.common.error.WxError;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.open.api.WxOpenMaPrivacyService;
-import me.chanjar.weixin.open.bean.ma.privacy.GetPrivacySettingResult;
-import me.chanjar.weixin.open.bean.ma.privacy.SetPrivacySetting;
-import me.chanjar.weixin.open.bean.ma.privacy.UploadPrivacyFileResult;
+import me.chanjar.weixin.open.bean.ma.privacy.*;
 import me.chanjar.weixin.open.util.json.WxOpenGsonBuilder;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,5 +49,17 @@ public class WxOpenMaPrivacyServiceImpl implements WxOpenMaPrivacyService {
 //    String json = wxMaService.execute(executor, OPEN_UPLOAD_PRIVACY_FILE, data);
 //    return WxOpenGsonBuilder.create().fromJson(json, UploadPrivacyFileResult.class);
     throw new WxErrorException(new WxError(5003, "暂未实现用户隐私指引内容上传"));
+  }
+
+  @Override
+  public GetPrivacyInterfaceResult getPrivacyInterface() throws WxErrorException {
+    String json = wxMaService.get(GET_PRIVATE_INTERFACE, "");
+    return WxOpenGsonBuilder.create().fromJson(json, GetPrivacyInterfaceResult.class);
+  }
+
+  @Override
+  public ApplyPrivacyInterfaceResult applyPrivacyInterface(ApplyPrivacyInterface dto) throws WxErrorException {
+    String json = wxMaService.post(APPLY_PRIVATE_INTERFACE, dto);
+    return WxOpenGsonBuilder.create().fromJson(json, ApplyPrivacyInterfaceResult.class);
   }
 }

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/ma/privacy/ApplyPrivacyInterface.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/ma/privacy/ApplyPrivacyInterface.java
@@ -1,0 +1,47 @@
+package me.chanjar.weixin.open.bean.ma.privacy;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 申请隐私接口
+ *
+ * @author <a href="https://www.sacoc.cn">广州跨界</a>
+ */
+@Getter
+@Setter
+public class ApplyPrivacyInterface {
+
+  /**
+   * 接口英文名称，如：wx.chooseAddress/wx.choosePoi/wx.getLocation/wx.onLocationChange/wx.chooseLocation
+   */
+  @SerializedName("api_name")
+  private String apiName;
+
+  /**
+   * 申请说原因，不超过300个字符；需要以utf-8编码提交，否则会出现审核失败
+   */
+  @SerializedName("content")
+  private String content;
+
+  /**
+   * (辅助网页)例如，上传官网网页链接用于辅助审核
+   */
+  @SerializedName("url_list")
+  private List<String> urlList;
+
+  /**
+   * (辅助图片)填写图片的url ，最多10个
+   */
+  @SerializedName("pic_list")
+  private List<String> picList;
+
+  /**
+   * (辅助视频)填写视频的链接 ，最多支持1个；视频格式只支持mp4格式
+   */
+  @SerializedName("video_list")
+  private List<String> videoList;
+}

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/ma/privacy/ApplyPrivacyInterfaceResult.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/ma/privacy/ApplyPrivacyInterfaceResult.java
@@ -1,0 +1,23 @@
+package me.chanjar.weixin.open.bean.ma.privacy;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import me.chanjar.weixin.open.bean.result.WxOpenResult;
+
+/**
+ * 获取接口列表 响应
+ *
+ * @author <a href="https://www.sacoc.cn">广州跨界</a>
+ */
+@Getter
+@Setter
+public class ApplyPrivacyInterfaceResult extends WxOpenResult {
+
+  /**
+   * 审核ID
+   */
+  @SerializedName("audit_id")
+  private Long auditId;
+
+}

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/ma/privacy/GetPrivacyInterfaceResult.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/ma/privacy/GetPrivacyInterfaceResult.java
@@ -1,0 +1,92 @@
+package me.chanjar.weixin.open.bean.ma.privacy;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import me.chanjar.weixin.open.bean.result.WxOpenResult;
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+
+/**
+ * 获取接口列表 响应
+ *
+ * @author <a href="https://www.sacoc.cn">广州跨界</a>
+ */
+@Getter
+@Setter
+public class GetPrivacyInterfaceResult extends WxOpenResult {
+
+  /**
+   * 隐私接口列表
+   */
+  @SerializedName("interface_list")
+  private List<Interface> interfaceList;
+
+
+  /**
+   * 隐私接口
+   */
+  @Getter
+  @Setter
+  public static class Interface {
+
+    /**
+     * 接口英文名称，如：wx.chooseAddress/wx.choosePoi/wx.getLocation/wx.onLocationChange/wx.chooseLocation
+     */
+    @SerializedName("api_name")
+    private String apiName;
+
+    /**
+     * 接口中文名称，如：获取用户收货地址/选择位置，支持模糊定位（精确到市）和精确定位混选/获取当前的地理位置、速度/监听实时地理位置变化事件/打开地图选择位置
+     */
+    @SerializedName("api_ch_name")
+    private String apiChName;
+
+    /**
+     * api描述
+     */
+    @SerializedName("api_desc")
+    private String apiDesc;
+
+    /**
+     * 申请时间 ，该字段发起申请后才会有
+     */
+    @Nullable
+    @SerializedName("apply_time")
+    private String applyTime;
+
+    /**
+     * 接口状态，该字段发起申请后才会有，1待申请开通，2无权限，3申请中，4申请失败，5已开通
+     */
+    @Nullable
+    @SerializedName("status")
+    private String status;
+
+    /**
+     * 申请单号，该字段发起申请后才会有
+     */
+    @Nullable
+    @SerializedName("audit_id")
+    private String auditId;
+
+    /**
+     * 申请被驳回原因或者无权限，该字段申请驳回时才会有
+     */
+    @Nullable
+    @SerializedName("fail_reason")
+    private String failReason;
+
+    /**
+     * api文档链接
+     */
+    @SerializedName("fail_reapi_linkason")
+    private String apiLink;
+
+    /**
+     * 分组名，如：地理位置
+     */
+    @SerializedName("group_name")
+    private String groupName;
+  }
+}


### PR DESCRIPTION
从2022年4月18日开始，部分小程序前端 api 需申请后，方可使用。该接口用于获取“需申请并审核通过”后才可使用的接口列表。