### PR TITLE
【企业微信】增加支持微盘文件权限接口

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveService.java
@@ -250,6 +250,36 @@ public interface WxCpOaWeDriveService {
   WxCpBaseResp fileAclDel(@NonNull WxCpFileAclDelRequest request) throws WxErrorException;
 
   /**
+   * 分享设置
+   * 该接口用于文件的分享设置。
+   * <p>
+   * 请求方式：POST（HTTPS）
+   * 请求地址: https://qyapi.weixin.qq.com/cgi-bin/wedrive/file_setting?access_token=ACCESS_TOKEN
+   *
+   * @param userId
+   * @param fileId
+   * @param authScope
+   * @param auth
+   * @return
+   * @throws WxErrorException
+   */
+  WxCpBaseResp fileSetting(@NonNull String userId, @NonNull String fileId, @NonNull Integer authScope, Integer auth) throws WxErrorException;
+
+  /**
+   * 获取分享链接
+   * 该接口用于获取文件的分享链接。
+   * <p>
+   * 请求方式：POST（HTTPS）
+   * 请求地址: https://qyapi.weixin.qq.com/cgi-bin/wedrive/file_share?access_token=ACCESS_TOKEN
+   *
+   * @param userId
+   * @param fileId
+   * @return
+   * @throws WxErrorException
+   */
+  WxCpFileShare fileShare(@NonNull String userId, @NonNull String fileId) throws WxErrorException;
+
+  /**
    * 文件信息
    * 该接口用于获取指定文件的信息。
    * <p>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOaWeDriveServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOaWeDriveServiceImpl.java
@@ -168,6 +168,30 @@ public class WxCpOaWeDriveServiceImpl implements WxCpOaWeDriveService {
   }
 
   @Override
+  public WxCpBaseResp fileSetting(@NonNull String userId, @NonNull String fileId, @NonNull Integer authScope, Integer auth) throws WxErrorException {
+    String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(FILE_SETTING);
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("userid", userId);
+    jsonObject.addProperty("fileid", fileId);
+    jsonObject.addProperty("auth_scope", authScope);
+    if (auth != null) {
+      jsonObject.addProperty("auth", auth);
+    }
+    String responseContent = this.cpService.post(apiUrl, jsonObject.toString());
+    return WxCpBaseResp.fromJson(responseContent);
+  }
+
+  @Override
+  public WxCpFileShare fileShare(@NonNull String userId, @NonNull String fileId) throws WxErrorException {
+    String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(FILE_SHARE);
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("userid", userId);
+    jsonObject.addProperty("fileid", fileId);
+    String responseContent = this.cpService.post(apiUrl, jsonObject.toString());
+    return WxCpFileShare.fromJson(responseContent);
+  }
+
+  @Override
   public WxCpFileInfo fileInfo(@NonNull String userId, @NonNull String fileId) throws WxErrorException {
     String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(FILE_INFO);
     JsonObject jsonObject = new JsonObject();

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/wedrive/WxCpFileShare.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/wedrive/WxCpFileShare.java
@@ -1,0 +1,30 @@
+package me.chanjar.weixin.cp.bean.oa.wedrive;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.io.Serializable;
+
+/**
+ * 获取分享链接返回信息.
+ *
+ * @author Wang_Wong
+ */
+@Data
+public class WxCpFileShare extends WxCpBaseResp implements Serializable {
+  private static final long serialVersionUID = -5028321625142879581L;
+
+  @SerializedName("share_url")
+  private String shareUrl;
+
+  public static WxCpFileShare fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpFileShare.class);
+  }
+
+  public String toJson() {
+    return WxCpGsonBuilder.create().toJson(this);
+  }
+
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -163,6 +163,8 @@ public interface WxCpApiPathConsts {
     String FILE_INFO = "/cgi-bin/wedrive/file_info";
     String FILE_ACL_ADD = "/cgi-bin/wedrive/file_acl_add";
     String FILE_ACL_DEL = "/cgi-bin/wedrive/file_acl_del";
+    String FILE_SETTING = "/cgi-bin/wedrive/file_setting";
+    String FILE_SHARE = "/cgi-bin/wedrive/file_share";
 
     /**
      * 审批流程引擎

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveServiceTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveServiceTest.java
@@ -49,6 +49,19 @@ public class WxCpOaWeDriveServiceTest {
     String fileId = "s.ww45d3e188865aca30.652091685u4h_f.652344507ysDL";
     String fileId2 = "s.ww45d3e188865aca30.652091685u4h_f.652696024TU4P";
 
+
+    /**
+     * 获取分享链接
+     */
+    WxCpFileShare fileShare = cpService.getOaWeDriveService().fileShare(uId, fileId2);
+    log.info("获取分享链接返回结果为：{}", fileShare.toJson());
+
+    /**
+     * 分享设置
+     */
+    WxCpBaseResp fileSetting = cpService.getOaWeDriveService().fileSetting(uId, fileId2, 2, 1);
+    log.info("分享设置返回结果为：{}", fileSetting.toJson());
+
     /**
      * 删除指定人
      */

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaQrcodeService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaQrcodeService.java
@@ -11,7 +11,8 @@ import java.io.File;
  *
  * 接口A（createWxaCode）加上接口C（createQrcode），总共生成的码数量限制为100,000，请谨慎调用。
  *
- * 文档地址：https://mp.weixin.qq.com/debug/wxadoc/dev/api/qrcode.html
+ * 文档地址1：https://mp.weixin.qq.com/debug/wxadoc/dev/api/qrcode.html
+ * 文档地址2：https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/qr-code.html
  * </pre>
  *
  * @author <a href="https://github.com/binarywang">Binary Wang</a>


### PR DESCRIPTION
【企业微信】【小程序】
1、增加支持微盘文件权限接口
2、添加官方文档描述
3、官方文档：https://developer.work.weixin.qq.com/document/path/93658