### PR TITLE
fix: 发送企业红包#签名错误 

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/entpay/EntPayRedpackRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/entpay/EntPayRedpackRequest.java
@@ -149,6 +149,11 @@ public class EntPayRedpackRequest extends BaseWxPayRequest {
   }
 
   @Override
+  protected String[] getIgnoredParamsForSign() {
+    return new String[]{"sign_type"};
+  }
+
+  @Override
   protected void storeMap(Map<String, String> map) {
     map.put("mch_billno", mchBillNo);
     map.put("wxappid", wxAppId);


### PR DESCRIPTION
发送企业红包签名需要忽略sign_type，否则会报签名错误。