### PR TITLE
【企业微信】增加家校通讯录-变更回调事件类型

### DIFF
--- a/weixin-java-cp/src/main/java/com/tencent/wework/Finance.java
+++ b/weixin-java-cp/src/main/java/com/tencent/wework/Finance.java
@@ -5,9 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 
 /**
+ * 企业微信会话内容存档Finance类
  * 注意：
- * 此类必须配置在com.tencent.wework路径底下，否则会报错：
- * java.lang.UnsatisfiedLinkError: com.xxx.Finance.NewSdk()
+ * 此类必须配置在com.tencent.wework路径底下，否则会报错：java.lang.UnsatisfiedLinkError: com.xxx.Finance.NewSdk()
  * <p>
  * Q：JAVA版本的sdk报错UnsatisfiedLinkError？
  * A：请检查是否修改了sdk的包名。
@@ -15,7 +15,7 @@ import java.util.List;
  * 官方文档：
  * https://developer.work.weixin.qq.com/document/path/91552
  *
- * @author Wang_Wong
+ * @author <a href="https://github.com/0katekate0">Wang_Wong</a>
  * @date 2022-01-17
  */
 @Slf4j

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpConsts.java
@@ -143,6 +143,40 @@ public class WxCpConsts {
      */
     public static final String DELETE_SCHEDULE = "delete_schedule";
 
+    /**
+     * 家校通讯录事件
+     */
+    public static final String CHANGE_SCHOOL_CONTACT = "change_school_contact";
+
+  }
+
+  /**
+   * 家校通讯录变更事件CHANGE_TYPE
+   */
+  @UtilityClass
+  public static class SchoolContactChangeType {
+
+    /**
+     * 部门变更事件
+     * https://developer.work.weixin.qq.com/document/path/92052
+     */
+    public static final String CREATE_DEPARTMENT = "create_department";
+    public static final String UPDATE_DEPARTMENT = "update_department";
+    public static final String DELETE_DEPARTMENT = "delete_department";
+
+    /**
+     * 成员变更事件
+     * https://developer.work.weixin.qq.com/document/path/92032
+     */
+    public static final String CREATE_STUDENT = "create_student";
+    public static final String UPDATE_STUDENT = "update_student";
+    public static final String DELETE_STUDENT = "delete_student";
+    public static final String CREATE_PARENT = "create_parent";
+    public static final String UPDATE_PARENT = "update_parent";
+    public static final String DELETE_PARENT = "delete_parent";
+    public static final String SUBSCRIBE = "subscribe";
+    public static final String UNSUBSCRIBE = "unsubscribe";
+
   }
 
   /**

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpConsts.java
@@ -94,7 +94,7 @@ public class WxCpConsts {
     public static final String TASKCARD_CLICK = "taskcard_click";
 
     /**
-     * 企业成员添加外部联系人事件推送
+     * 企业成员添加外部联系人事件推送 & 会话存档客户同意进行聊天内容存档事件回调事件
      */
     public static final String CHANGE_EXTERNAL_CONTACT = "change_external_contact";
 
@@ -147,6 +147,22 @@ public class WxCpConsts {
      * 家校通讯录事件
      */
     public static final String CHANGE_SCHOOL_CONTACT = "change_school_contact";
+
+    /**
+     * 产生会话回调事件
+     */
+    public static final String MSGAUDIT_NOTIFY = "msgaudit_notify";
+
+  }
+
+  /**
+   * 会话存档事件CHANGE_TYPE
+   * https://developer.work.weixin.qq.com/document/path/92005
+   */
+  @UtilityClass
+  public static class MsgAuditChangeType {
+
+    public static final String MSG_AUDIT_APPROVED = "msg_audit_approved";
 
   }
 

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpMsgAuditTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpMsgAuditTest.java
@@ -1,10 +1,16 @@
 package me.chanjar.weixin.cp.api;
+
 import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.common.util.XmlUtils;
 import me.chanjar.weixin.cp.api.impl.WxCpServiceImpl;
+import me.chanjar.weixin.cp.bean.message.WxCpXmlMessage;
 import me.chanjar.weixin.cp.bean.msgaudit.*;
 import me.chanjar.weixin.cp.config.WxCpConfigStorage;
+import me.chanjar.weixin.cp.constant.WxCpConsts;
 import me.chanjar.weixin.cp.demo.WxCpDemoInMemoryConfigStorage;
+import me.chanjar.weixin.cp.util.xml.XStreamTransformer;
+import org.eclipse.jetty.util.ajax.JSON;
 import org.testng.annotations.Test;
 
 import java.io.InputStream;
@@ -37,6 +43,55 @@ public class WxCpMsgAuditTest {
     wxCpConfigStorage = config;
     cpService = new WxCpServiceImpl();
     cpService.setWxCpConfigStorage(config);
+
+
+    /**
+     * 客户同意进行聊天内容存档事件回调
+     * 配置了客户联系功能的成员添加外部联系人同意进行聊天内容存档时，回调该事件。
+     *
+     * https://developer.work.weixin.qq.com/document/path/92005
+     */
+    String msgAuditApprovedXml = "<xml>\n" +
+      "\t<ToUserName><![CDATA[toUser]]></ToUserName>\n" +
+      "\t<FromUserName><![CDATA[sys]]></FromUserName> \n" +
+      "\t<CreateTime>1403610513</CreateTime>\n" +
+      "\t<MsgType><![CDATA[event]]></MsgType>\n" +
+      "\t<Event><![CDATA[change_external_contact]]></Event>\n" +
+      "\t<ChangeType><![CDATA[msg_audit_approved]]></ChangeType>\n" +
+      "\t<UserID><![CDATA[zhangsan]]></UserID>\n" +
+      "\t<ExternalUserID><![CDATA[woAJ2GCAAABiuyujaWJHDDGi0mACHAAA]]></ExternalUserID>\n" +
+      "\t<WelcomeCode><![CDATA[WELCOMECODE]]></WelcomeCode>\n" +
+      "</xml>";
+
+    final WxCpXmlMessage msgAuditApprovedXmlMsg = XStreamTransformer.fromXml(WxCpXmlMessage.class, msgAuditApprovedXml);
+    msgAuditApprovedXmlMsg.setAllFieldsMap(XmlUtils.xml2Map(msgAuditApprovedXml));
+    log.info("msgAuditApprovedXmlMsg:{}", JSON.toString(msgAuditApprovedXmlMsg));
+
+    /**
+     * 产生会话回调事件
+     * 为了提升企业会话存档的使用性能，降低无效的轮询次数。
+     * 当企业收到或发送新消息时，企业微信可以以事件的形式推送到企业指定的url。回调间隔为15秒，在15秒内若有消息则触发回调，若无消息则不会触发回调。
+     *
+     * https://developer.work.weixin.qq.com/document/path/95039
+     */
+    String msgAuditNotifyXml = "<xml>\n" +
+      "   <ToUserName><![CDATA[CorpID]]></ToUserName>\n" +
+      "   <FromUserName><![CDATA[sys]]></FromUserName> \n" +
+      "   <CreateTime>1629101687</CreateTime>\n" +
+      "   <MsgType><![CDATA[event]]></MsgType>\n" +
+      "   <AgentID>2000004</AgentID>\n" +
+      "   <Event><![CDATA[msgaudit_notify]]></Event>\n" +
+      "</xml>";
+
+    final WxCpXmlMessage msgAuditNotifyXmlMsg = XStreamTransformer.fromXml(WxCpXmlMessage.class, msgAuditNotifyXml);
+    msgAuditNotifyXmlMsg.setAllFieldsMap(XmlUtils.xml2Map(msgAuditNotifyXml));
+    log.info("msgAuditNotifyXmlMsg:{}", JSON.toString(msgAuditNotifyXmlMsg));
+
+    /**
+     * 增加变更事件类型：产生会话回调事件
+     */
+    String msgauditNotify = WxCpConsts.EventType.MSGAUDIT_NOTIFY;
+
 
     /**
      * 仔细配置：

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpSchoolUserTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpSchoolUserTest.java
@@ -4,15 +4,20 @@ import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 import lombok.var;
 import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.XmlUtils;
 import me.chanjar.weixin.cp.api.impl.WxCpServiceImpl;
 import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.bean.message.WxCpXmlMessage;
 import me.chanjar.weixin.cp.bean.school.user.*;
 import me.chanjar.weixin.cp.config.WxCpConfigStorage;
 import me.chanjar.weixin.cp.demo.WxCpDemoInMemoryConfigStorage;
+import me.chanjar.weixin.cp.util.xml.XStreamTransformer;
+import org.eclipse.jetty.util.ajax.JSON;
 import org.testng.annotations.Test;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
 /**
  * 企业微信家校沟通相关接口.
@@ -45,6 +50,93 @@ public class WxCpSchoolUserTest {
 
     final String userId = "WangKai";
     final String exUserId = "wmOQpTDwAAJFHrryZ8I8ALLEZuLHIUKA";
+
+
+//    String changeContact = WxCpConsts.EventType.CHANGE_CONTACT;
+    /**
+     * 增加变更事件类型：
+     */
+//    WxCpConsts.EventType.CHANGE_SCHOOL_CONTACT;
+//    WxCpConsts.SchoolContactChangeType.DELETE_STUDENT;
+//    WxCpConsts.SchoolContactChangeType.CREATE_DEPARTMENT;
+
+    /**
+     * 测试家校通讯录变更回调
+     * https://developer.work.weixin.qq.com/document/path/92052
+     *
+     * 新增学生事件
+     * 当学校在家校通讯录中新增学生时，回调此事件。
+     */
+    String createStudentXml = "<xml>\n" +
+      "\t<ToUserName><![CDATA[toUser]]></ToUserName>\n" +
+      "\t<FromUserName><![CDATA[sys]]></FromUserName> \n" +
+      "\t<CreateTime>1403610513</CreateTime>\n" +
+      "\t<MsgType><![CDATA[event]]></MsgType>\n" +
+      "\t<Event><![CDATA[change_school_contact]]></Event>\n" +
+      "\t<ChangeType><![CDATA[create_student]]></ChangeType>\n" +
+      "\t<Id><![CDATA[xiaoming]]></Id>\n" +
+      "</xml>";
+
+    /**
+     * 家长取消关注事件
+     * 当家长取消关注家校通知时，回调此事件。
+     */
+    String unSubscribeXml = "<xml>\n" +
+      "\t<ToUserName><![CDATA[toUser]]></ToUserName>\n" +
+      "\t<FromUserName><![CDATA[sys]]></FromUserName> \n" +
+      "\t<CreateTime>1403610513</CreateTime>\n" +
+      "\t<MsgType><![CDATA[event]]></MsgType>\n" +
+      "\t<Event><![CDATA[change_school_contact]]></Event>\n" +
+      "\t<ChangeType><![CDATA[unsubscribe]]></ChangeType>\n" +
+      "\t<Id><![CDATA[xiaoming]]></Id>\n" +
+      "</xml>";
+
+    /**
+     * 创建部门事件
+     * 当学校在家校通讯录中创建部门时，回调此事件。
+     */
+    String createDepartmentXml = "<xml>\n" +
+      "\t<ToUserName><![CDATA[toUser]]></ToUserName>\n" +
+      "\t<FromUserName><![CDATA[sys]]></FromUserName> \n" +
+      "\t<CreateTime>1403610513</CreateTime>\n" +
+      "\t<MsgType><![CDATA[event]]></MsgType>\n" +
+      "\t<Event><![CDATA[change_school_contact]]></Event>\n" +
+      "\t<ChangeType><![CDATA[create_deparmtment]]></ChangeType>\n" +
+      "\t<Id><![CDATA[1]]></Id>\n" +
+      "</xml>";
+
+    /**
+     * 删除部门事件
+     * 当学校删除家校通讯录部门时，回调此事件。
+     */
+    String deleteDepartmentXml = "<xml>\n" +
+      "\t<ToUserName><![CDATA[toUser]]></ToUserName>\n" +
+      "\t<FromUserName><![CDATA[sys]]></FromUserName> \n" +
+      "\t<CreateTime>1403610513</CreateTime>\n" +
+      "\t<MsgType><![CDATA[event]]></MsgType>\n" +
+      "\t<Event><![CDATA[change_school_contact]]></Event>\n" +
+      "\t<ChangeType><![CDATA[delete_deparmtment]]></ChangeType>\n" +
+      "\t<Id><![CDATA[1]]></Id>\n" +
+      "</xml>";
+
+//    WxCpXmlMessage.fromXml(createStudentXml);
+    final WxCpXmlMessage createStudentMsg = XStreamTransformer.fromXml(WxCpXmlMessage.class, createStudentXml);
+    Map<String, Object> map1 = XmlUtils.xml2Map(createStudentXml);
+    createStudentMsg.setAllFieldsMap(map1);
+    log.info("createStudentMsg:{}", JSON.toString(createStudentMsg));
+
+    final WxCpXmlMessage unSubscribeMsg = XStreamTransformer.fromXml(WxCpXmlMessage.class, unSubscribeXml);
+    Map<String, Object> map2 = XmlUtils.xml2Map(unSubscribeXml);
+    unSubscribeMsg.setAllFieldsMap(map2);
+    log.info("unSubscribeMsg:{}", JSON.toString(unSubscribeMsg));
+
+    final WxCpXmlMessage createDepartmentMsg = XStreamTransformer.fromXml(WxCpXmlMessage.class, createDepartmentXml);
+    createDepartmentMsg.setAllFieldsMap(XmlUtils.xml2Map(createDepartmentXml));
+    log.info("createDepartmentMsg:{}", JSON.toString(createDepartmentMsg));
+
+    final WxCpXmlMessage deleteDepartmentMsg = XStreamTransformer.fromXml(WxCpXmlMessage.class, deleteDepartmentXml);
+    deleteDepartmentMsg.setAllFieldsMap(XmlUtils.xml2Map(deleteDepartmentXml));
+    log.info("deleteDepartmentMsg:{}", JSON.toString(deleteDepartmentMsg));
 
 
     /**


### PR DESCRIPTION
【企业微信】增加家校通讯录-变更回调事件类型
1、增加家校通讯录-变更回调全部事件类型
2、https://developer.work.weixin.qq.com/document/path/92032