### PR TITLE
🎨 修复错误的注解

### DIFF
--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/ma/WxMaOpenCommitStandardExt.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/ma/WxMaOpenCommitStandardExt.java
@@ -40,7 +40,7 @@ public class WxMaOpenCommitStandardExt implements Serializable {
   /**
    * 授权小程序Appid，可填入商户小程序AppID，以区分不同商户
    */
-  @SerializedName("extAppId")
+  @SerializedName("extAppid")
   private String extAppId;
 
   /**


### PR DESCRIPTION
微信小程序上传代码接口ext_json中的extAppid字段id为小写