### PR TITLE
:bug: #2788 `unoinId` 使用 Integer 溢出导致GSON抛出NumberFormatException

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/safety/response/WxMaUserSafetyRiskRankResponse.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/safety/response/WxMaUserSafetyRiskRankResponse.java
@@ -26,7 +26,7 @@ public class WxMaUserSafetyRiskRankResponse implements Serializable {
    * 唯一请求标识，标记单次请求
    */
   @SerializedName("unoin_id")
-  private Integer unoinId;
+  private Long unoinId;
 
   /**
    * 用户风险等级


### PR DESCRIPTION
官方文档地址：[riskControl.getUserRiskRank](https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/safety-control-capability/riskControl.getUserRiskRank.html)  
官方返回值 `unoinId` 标记为 `number` 类型，Java中使用 Integer 导致整数溢出，修改为 Long 类型。