### PR TITLE
【小程序】增加新版自定义交易组件获取售后单详情API

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaShopAfterSaleService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaShopAfterSaleService.java
@@ -1,16 +1,7 @@
 package cn.binarywang.wx.miniapp.api;
 
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAcceptReturnRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleAddRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleGetRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleListRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleUpdateRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleUploadReturnInfoRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopUploadCerficatesRequest;
-import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopAfterSaleAddResponse;
-import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopAfterSaleGetResponse;
-import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopAfterSaleListResponse;
-import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopBaseResponse;
+import cn.binarywang.wx.miniapp.bean.shop.request.*;
+import cn.binarywang.wx.miniapp.bean.shop.response.*;
 import me.chanjar.weixin.common.error.WxErrorException;
 
 /**
@@ -37,6 +28,15 @@ public interface WxMaShopAfterSaleService {
    * @throws WxErrorException
    */
   WxMaShopAfterSaleGetResponse get(WxMaShopAfterSaleGetRequest request) throws WxErrorException;
+
+  /**
+   * 获取售后单详情(EC版)
+   *
+   * @param request
+   * @return WxMaShopEcAfterSaleGetResponse
+   * @throws WxErrorException
+   */
+  WxMaShopEcAfterSaleGetResponse get(WxMaShopEcAfterSaleGetRequest request) throws WxErrorException;
 
   /**
    * 更新售后

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopAfterSaleServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopAfterSaleServiceImpl.java
@@ -2,17 +2,8 @@ package cn.binarywang.wx.miniapp.api.impl;
 
 import cn.binarywang.wx.miniapp.api.WxMaService;
 import cn.binarywang.wx.miniapp.api.WxMaShopAfterSaleService;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAcceptReturnRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleAddRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleGetRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleListRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleUpdateRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleUploadReturnInfoRequest;
-import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopUploadCerficatesRequest;
-import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopAfterSaleAddResponse;
-import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopAfterSaleGetResponse;
-import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopAfterSaleListResponse;
-import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopBaseResponse;
+import cn.binarywang.wx.miniapp.bean.shop.request.*;
+import cn.binarywang.wx.miniapp.bean.shop.response.*;
 import cn.binarywang.wx.miniapp.json.WxMaGsonBuilder;
 import com.google.gson.JsonObject;
 import lombok.RequiredArgsConstructor;
@@ -68,6 +59,23 @@ public class WxMaShopAfterSaleServiceImpl implements WxMaShopAfterSaleService {
       throw new WxErrorException(WxError.fromJson(responseContent, WxType.MiniApp));
     }
     return WxMaGsonBuilder.create().fromJson(responseContent, WxMaShopAfterSaleGetResponse.class);
+  }
+
+  /**
+   * 获取售后单详情(EC版)
+   *
+   * @param request
+   * @return WxMaShopEcAfterSaleGetResponse
+   * @throws WxErrorException
+   */
+  @Override
+  public WxMaShopEcAfterSaleGetResponse get(WxMaShopEcAfterSaleGetRequest request) throws WxErrorException {
+    String responseContent = this.wxMaService.post(ECAFTERSALE_GET, request);
+    JsonObject jsonObject = GsonParser.parse(responseContent);
+    if (jsonObject.get(ERRCODE).getAsInt() != 0) {
+      throw new WxErrorException(WxError.fromJson(responseContent, WxType.MiniApp));
+    }
+    return WxMaGsonBuilder.create().fromJson(responseContent, WxMaShopEcAfterSaleGetResponse.class);
   }
 
   /**

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/request/WxMaShopEcAfterSaleGetRequest.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/request/WxMaShopEcAfterSaleGetRequest.java
@@ -1,0 +1,27 @@
+package cn.binarywang.wx.miniapp.bean.shop.request;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * @author liming1019
+ * created on  2022/8/25
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WxMaShopEcAfterSaleGetRequest implements Serializable {
+
+  private static final long serialVersionUID = -1967384908983649001L;
+
+  @SerializedName("aftersale_id")
+  private Long aftersaleId;
+  @SerializedName("out_aftersale_id")
+  private String outAftersaleId;
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/response/WxMaShopEcAfterSaleGetResponse.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/response/WxMaShopEcAfterSaleGetResponse.java
@@ -1,0 +1,73 @@
+package cn.binarywang.wx.miniapp.bean.shop.response;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+
+/**
+ * @author liming1019
+ * created on  2022/8/25
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WxMaShopEcAfterSaleGetResponse extends WxMaShopBaseResponse implements Serializable {
+
+  private static final long serialVersionUID = -338753264205536337L;
+
+  @SerializedName("after_sales_order")
+  private AfterSalesOrderDTO afterSalesOrder;
+
+  @Data
+  public static class AfterSalesOrderDTO implements Serializable {
+    @SerializedName("out_aftersale_id")
+    private String outAftersaleId;
+    @SerializedName("aftersale_id")
+    private Long aftersaleId;
+    @SerializedName("out_order_id")
+    private String outOrderId;
+    @SerializedName("order_id")
+    private Long orderId;
+    @SerializedName("product_info")
+    private ProductInfoDTO productInfo;
+    @SerializedName("type")
+    private Integer type;
+    @SerializedName("return_info")
+    private ReturnInfoDTO returnInfo;
+    @SerializedName("orderamt")
+    private Integer orderamt;
+    @SerializedName("refund_reason_type")
+    private Integer refundReasonType;
+    @SerializedName("refund_reason")
+    private String refundReason;
+    @SerializedName("status")
+    private Integer status;
+    @SerializedName("create_time")
+    private String createTime;
+    @SerializedName("update_time")
+    private String updateTime;
+
+    @Data
+    public static class ProductInfoDTO implements Serializable {
+      @SerializedName("out_product_id")
+      private String outProductId;
+      @SerializedName("out_sku_id")
+      private String outSkuId;
+      @SerializedName("product_cnt")
+      private Integer productCnt;
+    }
+
+    @Data
+    public static class ReturnInfoDTO implements Serializable {
+      @SerializedName("order_return_time")
+      private String orderReturnTime;
+      @SerializedName("delivery_id")
+      private String deliveryId;
+      @SerializedName("waybill_id")
+      private String waybillId;
+      @SerializedName("delivery_name")
+      private String deliveryName;
+    }
+  }
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/constant/WxMaApiUrlConstants.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/constant/WxMaApiUrlConstants.java
@@ -511,7 +511,8 @@ public class WxMaApiUrlConstants {
       String AFTERSALE_UPLOAD_CERTIFICATES = "https://api.weixin.qq.com/shop/ecaftersale/upload_certificates";
       String AFTERSALE_UPLOAD_DEADLINE = "https://api.weixin.qq.com/shop/aftersale/update_deadline";
       String AFTERSALE_GET_LIST = "https://api.weixin.qq.com/shop/ecaftersale/get_list";
-      String AFTERSALE_GET = "https://api.weixin.qq.com/shop/ecaftersale/get";
+      String AFTERSALE_GET = "https://api.weixin.qq.com/shop/aftersale/get";
+      String ECAFTERSALE_GET = "https://api.weixin.qq.com/shop/ecaftersale/get";
     }
 
     interface Sharer {

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopAfterSaleServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopAfterSaleServiceImplTest.java
@@ -4,8 +4,10 @@ import cn.binarywang.wx.miniapp.api.WxMaService;
 import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleAddRequest;
 import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleGetRequest;
 import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopAfterSaleUpdateRequest;
+import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopEcAfterSaleGetRequest;
 import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopAfterSaleGetResponse;
 import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopBaseResponse;
+import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopEcAfterSaleGetResponse;
 import cn.binarywang.wx.miniapp.test.ApiTestModule;
 import com.google.inject.Inject;
 import me.chanjar.weixin.common.error.WxErrorException;
@@ -71,4 +73,15 @@ public class WxMaShopAfterSaleServiceImplTest {
     WxMaShopBaseResponse response = wxService.getShopAfterSaleService().update(request);
     assertThat(response).isNotNull();
   }
+
+  @Test
+  public void testEcGet() throws WxErrorException {
+    WxMaShopEcAfterSaleGetRequest request = WxMaShopEcAfterSaleGetRequest.builder()
+      .aftersaleId(123L)
+      .outAftersaleId("aso_123124341")
+      .build();
+    WxMaShopEcAfterSaleGetResponse response = wxService.getShopAfterSaleService().get(request);
+    assertThat(response).isNotNull();
+  }
+
 }


### PR DESCRIPTION
https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/business-capabilities/ministore/minishopopencomponent2/API/aftersale/get_new.html

此API之前被修改过，只将URL改成了新版，没有改请求参数和输出参数，导致SDK报错。本次修复恢复了旧版本URL，将新接口独立出来一个API。与微信官方API保持一致。