### PR TITLE
【小程序】增加新版自定义交易组件之更新售后申请API

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaShopAfterSaleService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaShopAfterSaleService.java
@@ -48,6 +48,16 @@ public interface WxMaShopAfterSaleService {
   WxMaShopBaseResponse update(WxMaShopAfterSaleUpdateRequest request) throws WxErrorException;
 
   /**
+   * 更新售后(EC版)
+   *
+   * @param request
+   * @return WxMaShopBaseResponse
+   * @throws WxErrorException
+   */
+  WxMaShopBaseResponse update(WxMaShopEcAfterSaleUpdateRequest request) throws WxErrorException;
+
+
+  /**
    * 用户取消售后申请
    * @param outAfterSaleId 商家自定义订单ID
    * @param afterSaleId 与out_aftersale_id二选一

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopAfterSaleServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopAfterSaleServiceImpl.java
@@ -95,6 +95,16 @@ public class WxMaShopAfterSaleServiceImpl implements WxMaShopAfterSaleService {
     return WxMaGsonBuilder.create().fromJson(responseContent, WxMaShopBaseResponse.class);
   }
 
+  @Override
+  public WxMaShopBaseResponse update(WxMaShopEcAfterSaleUpdateRequest request) throws WxErrorException {
+    String responseContent = this.wxMaService.post(EC_AFTERSALE_UPDATE, request);
+    JsonObject jsonObject = GsonParser.parse(responseContent);
+    if (jsonObject.get(ERRCODE).getAsInt() != 0) {
+      throw new WxErrorException(WxError.fromJson(responseContent, WxType.MiniApp));
+    }
+    return WxMaGsonBuilder.create().fromJson(responseContent, WxMaShopBaseResponse.class);
+  }
+
   /**
    * 用户取消售后申请
    * @param outAfterSaleId 商家自定义订单ID

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/request/WxMaShopAfterSaleUpdateRequest.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/request/WxMaShopAfterSaleUpdateRequest.java
@@ -34,16 +34,6 @@ public class WxMaShopAfterSaleUpdateRequest implements Serializable {
   private String openid;
   @SerializedName("out_aftersale_id")
   private String outAftersaleId;
-  @SerializedName("type")
-  private Integer type;
-  @SerializedName("orderamt")
-  private Long orderamt;
-  @SerializedName("refund_reason")
-  private String refundReason;
-  @SerializedName("refund_reason_type")
-  private Integer refundReasonType;
-  @SerializedName("media_list")
-  private UploadMediaList mediaList;
   @SerializedName("status")
   private Integer status;
   @SerializedName("finish_all_aftersale")

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/request/WxMaShopEcAfterSaleUpdateRequest.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/shop/request/WxMaShopEcAfterSaleUpdateRequest.java
@@ -1,0 +1,50 @@
+package cn.binarywang.wx.miniapp.bean.shop.request;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author liming1019
+ * created on  2022/8/26
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WxMaShopEcAfterSaleUpdateRequest implements Serializable {
+  private static final long serialVersionUID = 349486861004919697L;
+
+  @SerializedName("out_aftersale_id")
+  private String outAftersaleId;
+  @SerializedName("aftersale_id")
+  private String aftersaleId;
+  @SerializedName("openid")
+  private String openid;
+  @SerializedName("type")
+  private int type;
+  @SerializedName("orderamt")
+  private int orderamt;
+  @SerializedName("refund_reason")
+  private String refundReason;
+  @SerializedName("refund_reason_type")
+  private int refundReasonType;
+  @SerializedName("media_list")
+  private List<MediaListBean> mediaList;
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class MediaListBean implements Serializable {
+    @SerializedName("type")
+    private int type;
+    @SerializedName("url")
+    private String url;
+  }
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/constant/WxMaApiUrlConstants.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/constant/WxMaApiUrlConstants.java
@@ -503,7 +503,8 @@ public class WxMaApiUrlConstants {
     interface Aftersale {
       String AFTERSALE_ADD = "https://api.weixin.qq.com/shop/ecaftersale/add";
       String AFTERSALE_CANCEL = "https://api.weixin.qq.com/shop/ecaftersale/cancel";
-      String AFTERSALE_UPDATE = "https://api.weixin.qq.com/shop/ecaftersale/update";
+      String AFTERSALE_UPDATE = "https://api.weixin.qq.com/shop/aftersale/update";
+      String EC_AFTERSALE_UPDATE = "https://api.weixin.qq.com/shop/ecaftersale/update";
       String AFTERSALE_UPLOAD_RETURN_INFO = "https://api.weixin.qq.com/shop/ecaftersale/uploadreturninfo";
       String AFTERSALE_ACCEPT_REFUND = "https://api.weixin.qq.com/shop/ecaftersale/acceptrefund";
       String AFTERSALE_ACCEPT_RETURN = "https://api.weixin.qq.com/shop/ecaftersale/acceptreturn";


### PR DESCRIPTION
新版API升级后，参数与旧版API不同，之前SDK的做法的将新旧的参数混合在一起，并将URL直接改为新版，造成使用者困惑，现将新版与旧版分离开，保证与官方API文档保持一致。
旧版：https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/business-capabilities/ministore/minishopopencomponent2/API/aftersale/update.html
新版：https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/business-capabilities/ministore/minishopopencomponent2/API/aftersale/aftersale_update.html