### PR TITLE
用户管理相关操作接口-PR了一个重载方法，调用方无需多次调用拼接数据

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpUserService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpUserService.java
@@ -95,6 +95,19 @@ public interface WxMpUserService {
 
   /**
    * <pre>
+   * 获取用户列表（全部）
+   * 公众号可通过本接口来获取帐号的关注者列表，
+   * 关注者列表由一串OpenID（加密后的微信号，每个用户对每个公众号的OpenID是唯一的）组成。
+   * @see #userList(java.lang.String) 的增强，内部进行了多次数据拉取的汇总
+   * 详情请见: http://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140840&token=&lang=zh_CN
+   * http请求方式: GET（请使用https协议）
+   * 接口地址：https://api.weixin.qq.com/cgi-bin/user/get?access_token=ACCESS_TOKEN&next_openid=NEXT_OPENID
+   * </pre>
+   */
+  WxMpUserList userList() throws WxErrorException;
+
+  /**
+   * <pre>
    * 微信公众号主体变更迁移用户 openid
    * 详情请见: http://kf.qq.com/faq/170221aUnmmU170221eUZJNf.html
    * http://kf.qq.com/faq/1901177NrqMr190117nqYJze.html

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpUserServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpUserServiceImpl.java
@@ -10,6 +10,7 @@ import me.chanjar.weixin.mp.bean.result.WxMpChangeOpenid;
 import me.chanjar.weixin.mp.bean.result.WxMpUser;
 import me.chanjar.weixin.mp.bean.result.WxMpUserList;
 import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +51,25 @@ public class WxMpUserServiceImpl implements WxMpUserService {
   public WxMpUserList userList(String nextOpenid) throws WxErrorException {
     String responseContent = this.wxMpService.get(USER_GET_URL, nextOpenid == null ? null : "next_openid=" + nextOpenid);
     return WxMpUserList.fromJson(responseContent);
+  }
+
+  @Override
+  public WxMpUserList userList() throws WxErrorException {
+    String responseContent = this.wxMpService.get(USER_GET_URL, null);
+    WxMpUserList merageList = new WxMpUserList();
+
+    WxMpUserList wxMpUserList = WxMpUserList.fromJson(responseContent);
+    merageList.getOpenids().addAll(wxMpUserList.getOpenids());
+    merageList.setCount(wxMpUserList.getCount());
+    merageList.setTotal(wxMpUserList.getTotal());
+
+    while (StringUtils.isNotEmpty(wxMpUserList.getNextOpenid())) {
+      WxMpUserList nextReqUserList = userList(wxMpUserList.getNextOpenid());
+      merageList.getOpenids().addAll(nextReqUserList.getOpenids());
+      merageList.setCount(merageList.getCount() + nextReqUserList.getCount());
+      wxMpUserList = nextReqUserList;
+    }
+    return merageList;
   }
 
   @Override

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpUserServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpUserServiceImpl.java
@@ -56,20 +56,20 @@ public class WxMpUserServiceImpl implements WxMpUserService {
   @Override
   public WxMpUserList userList() throws WxErrorException {
     String responseContent = this.wxMpService.get(USER_GET_URL, null);
-    WxMpUserList merageList = new WxMpUserList();
+    WxMpUserList mergeList = new WxMpUserList();
 
     WxMpUserList wxMpUserList = WxMpUserList.fromJson(responseContent);
-    merageList.getOpenids().addAll(wxMpUserList.getOpenids());
-    merageList.setCount(wxMpUserList.getCount());
-    merageList.setTotal(wxMpUserList.getTotal());
+    mergeList.getOpenids().addAll(wxMpUserList.getOpenids());
+    mergeList.setCount(wxMpUserList.getCount());
+    mergeList.setTotal(wxMpUserList.getTotal());
 
     while (StringUtils.isNotEmpty(wxMpUserList.getNextOpenid())) {
       WxMpUserList nextReqUserList = userList(wxMpUserList.getNextOpenid());
-      merageList.getOpenids().addAll(nextReqUserList.getOpenids());
-      merageList.setCount(merageList.getCount() + nextReqUserList.getCount());
+      mergeList.getOpenids().addAll(nextReqUserList.getOpenids());
+      mergeList.setCount(mergeList.getCount() + nextReqUserList.getCount());
       wxMpUserList = nextReqUserList;
     }
-    return merageList;
+    return mergeList;
   }
 
   @Override


### PR DESCRIPTION
me.chanjar.weixin.mp.api.WxMpUserService#userList()
该接口新增一个重载方法，调用方无需多次调用来拼接全量数据，内部实现存在 nextOpenid 的时候，自动进行调用，进行merage操作