### PR TITLE
修复小程序支付管理获取订单详情接口请求参数格式错误

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopPayServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopPayServiceImpl.java
@@ -7,9 +7,11 @@ import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopPayOrderRefundRequest;
 import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopBaseResponse;
 import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopPayCreateOrderResponse;
 import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopPayGetOrderResponse;
+import com.google.gson.JsonObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.json.GsonHelper;
 import me.chanjar.weixin.common.util.json.WxGsonBuilder;
 
 import static cn.binarywang.wx.miniapp.constant.WxMaApiUrlConstants.Shop.Pay.*;
@@ -32,7 +34,8 @@ public class WxMaShopPayServiceImpl implements WxMaShopPayService {
 
   @Override
   public WxMaShopPayGetOrderResponse getOrder(String tradeNo) throws WxErrorException {
-    String response = this.wxMaService.post(GET_ORDER, tradeNo);
+    JsonObject request = GsonHelper.buildJsonObject("trade_no", tradeNo);
+    String response = this.wxMaService.post(GET_ORDER, request);
     return WxGsonBuilder.create().fromJson(response, WxMaShopPayGetOrderResponse.class);
   }
 

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopPayServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaShopPayServiceImplTest.java
@@ -3,6 +3,7 @@ package cn.binarywang.wx.miniapp.api.impl;
 import cn.binarywang.wx.miniapp.api.WxMaService;
 import cn.binarywang.wx.miniapp.bean.shop.request.WxMaShopPayCreateOrderRequest;
 import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopPayCreateOrderResponse;
+import cn.binarywang.wx.miniapp.bean.shop.response.WxMaShopPayGetOrderResponse;
 import cn.binarywang.wx.miniapp.test.ApiTestModule;
 import com.google.inject.Inject;
 import org.testng.annotations.Guice;
@@ -35,6 +36,12 @@ public class WxMaShopPayServiceImplTest {
         ))
         .build();
     WxMaShopPayCreateOrderResponse response = wxService.getWxMaShopPayService().createOrder(request);
+    assertThat(response).isNotNull();
+  }
+
+  @Test
+  public void testGetOrder() throws Exception {
+    WxMaShopPayGetOrderResponse response = wxService.getWxMaShopPayService().getOrder("457243057210572800");
     assertThat(response).isNotNull();
   }
 }


### PR DESCRIPTION
正确API入参格式为{"trade_no": "123455"}，错误的传成了123455，本次修复了入参格式。
https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/business-capabilities/ministore/wxafunds/API/order/get_order_detail.html