### PR TITLE
修复小程序交易组件 商品spu list接口返回值缺少productId字段的严重bug

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/product/WxMinishopSpu.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/product/WxMinishopSpu.java
@@ -9,6 +9,9 @@ import lombok.Data;
 public class WxMinishopSpu implements Serializable {
   private static final long serialVersionUID = 6689040014027161007L;
 
+  @SerializedName("product_id")
+  private String productId;
+
   @SerializedName("out_product_id")
   private String outProductId;
 


### PR DESCRIPTION
https://developers.weixin.qq.com/miniprogram/dev/platform-capabilities/business-capabilities/ministore/minishopopencomponent/API/spu/get_spu_list.html

该接口的实现返回值的实体类，缺少了最重要的product_id字段，导致调用者没法从list中获取商品的id