### PR TITLE
【企业微信】新增API: 将代开发应用或第三方应用获取的externaluserid转换成自建应用的externaluserid

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpExternalContactService.java
@@ -240,6 +240,23 @@ public interface WxCpExternalContactService {
   String toServiceExternalUserid(String externalUserid) throws WxErrorException;
 
   /**
+   * 将代开发应用或第三方应用获取的externaluserid转换成自建应用的externaluserid
+   * <pre>
+   * 文档地址：https://developer.work.weixin.qq.com/document/path/95884#external-userid%E8%BD%AC%E6%8D%A2
+   *
+   * 权限说明：
+   *
+   * 需要使用自建应用或基础应用的access_token
+   * 客户的跟进人，或者用户所在客户群的群主，需要同时在access_token和source_agentid所对应应用的可见范围内
+   * </pre>
+   * @param externalUserid 服务商主体的external_userid，必须是source_agentid对应的应用所获取
+   * @param sourceAgentId 企业授权的代开发自建应用或第三方应用的agentid
+   * @return
+   * @throws WxErrorException
+   */
+  String fromServiceExternalUserid(String externalUserid, String sourceAgentId) throws WxErrorException;
+
+  /**
    * 企业客户微信unionid的升级 - unionid查询external_userid
    * <pre>
    *

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpExternalContactServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpExternalContactServiceImpl.java
@@ -153,6 +153,16 @@ public class WxCpExternalContactServiceImpl implements WxCpExternalContactServic
   }
 
   @Override
+  public String fromServiceExternalUserid(String externalUserid, String sourceAgentId) throws WxErrorException {
+    JsonObject json = new JsonObject();
+    json.addProperty("external_userid", externalUserid);
+    json.addProperty("source_agentid", sourceAgentId);
+    final String url = this.mainService.getWxCpConfigStorage().getApiUrl(FROM_SERVICE_EXTERNAL_USERID);
+    String responseContent = this.mainService.post(url, json.toString());
+    JsonObject tmpJson = GsonParser.parse(responseContent);
+    return tmpJson.get("external_userid").getAsString();
+  }
+  @Override
   public WxCpExternalUserIdList unionidToExternalUserid3rd(String unionid, String openid,
                                                            String corpid) throws WxErrorException {
     JsonObject json = new JsonObject();

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -997,6 +997,10 @@ public interface WxCpApiPathConsts {
      */
     String TO_SERVICE_EXTERNAL_USERID = "/cgi-bin/externalcontact/to_service_external_userid";
     /**
+     * The constant FROM_SERVICE_EXTERNAL_USERID.
+     */
+    String FROM_SERVICE_EXTERNAL_USERID = "/cgi-bin/externalcontact/from_service_external_userid";
+    /**
      * The constant FINISH_EXTERNAL_USERID_MIGRATION.
      */
     String FINISH_EXTERNAL_USERID_MIGRATION = "/cgi-bin/externalcontact/finish_external_userid_migration";


### PR DESCRIPTION
【企业微信】新增API: 将代开发应用或第三方应用获取的externaluserid转换成自建应用的externaluserid  
官方文档：[https://developer.work.weixin.qq.com/document/path/95884#external-userid%E8%BD%AC%E6%8D%A2](https://developer.work.weixin.qq.com/document/path/95884#external-userid%E8%BD%AC%E6%8D%A2)