### PR TITLE
fix：【企业微信】修复external_userid的转换接口url不对的bug

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -995,7 +995,7 @@ public interface WxCpApiPathConsts {
     /**
      * The constant GET_NEW_EXTERNAL_USERID.
      */
-    String GET_NEW_EXTERNAL_USERID = "/cgi-bin/service/externalcontact/get_new_external_userid";
+    String GET_NEW_EXTERNAL_USERID = "/cgi-bin/externalcontact/get_new_external_userid";
     /**
      * The constant TO_SERVICE_EXTERNAL_USERID.
      */


### PR DESCRIPTION
官方文档：https://developer.work.weixin.qq.com/document/path/95327#%E8%BD%AC%E6%8D%A2external_userid