### PR TITLE
【企业微信】获取访问用户敏感信息接口中增加地址和企业邮箱字段

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUser.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUser.java
@@ -28,10 +28,25 @@ public class WxCpUser implements Serializable {
   private Integer[] orders;
   private String position;
   private String[] positions;
+  /**
+   * 代开发自建应用类型于2022年6月20号后的新建应用将不再返回此字段，需要在【获取访问用户敏感信息】接口中获取
+   */
   private String mobile;
+  /**
+   * 代开发自建应用类型于2022年6月20号后的新建应用将不再返回此字段，需要在【获取访问用户敏感信息】接口中获取
+   */
   private Gender gender;
+  /**
+   * 代开发自建应用类型于2022年6月20号后的新建应用将不再返回此字段，需要在【获取访问用户敏感信息】接口中获取
+   */
   private String email;
+  /**
+   * 代开发自建应用类型于2022年6月20号后的新建应用将不再返回此字段，需要在【获取访问用户敏感信息】接口中获取
+   */
   private String bizMail;
+  /**
+   * 代开发自建应用类型于2022年6月20号后的新建应用将不再返回此字段，需要在【获取访问用户敏感信息】接口中获取
+   */
   private String avatar;
   private String thumbAvatar;
   private String mainDepartment;
@@ -41,7 +56,7 @@ public class WxCpUser implements Serializable {
   private String openUserId;
 
   /**
-   * 地址。长度最大128个字符
+   * 地址。长度最大128个字符，代开发自建应用类型于2022年6月20号后的新建应用将不再返回此字段，需要在【获取访问用户敏感信息】接口中获取
    */
   private String address;
   private String avatarMediaId;
@@ -61,6 +76,9 @@ public class WxCpUser implements Serializable {
   private Integer hideMobile;
   private String englishName;
   private String telephone;
+  /**
+   * 代开发自建应用类型于2022年6月20号后的新建应用将不再返回此字段，需要在【获取访问用户敏感信息】接口中获取
+   */
   private String qrCode;
   private Boolean toInvite;
   /**

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUserDetail.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUserDetail.java
@@ -62,7 +62,7 @@ public class WxCpUserDetail implements Serializable {
   private String bizMail;
 
   /**
-   * 企业邮箱，仅在用户同意snsapi_privateinfo授权时返回，2022年6月20号后的新应用将返回
+   * 地址，仅在用户同意snsapi_privateinfo授权时返回，2022年6月20号后的新应用将返回
    */
   private String address;
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUserDetail.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpUserDetail.java
@@ -25,7 +25,7 @@ public class WxCpUserDetail implements Serializable {
   private String userId;
 
   /**
-   * 成员姓名
+   * 成员姓名，2022年6月20号后的新应用将不再返回此字段，旧应用正常返回
    */
   private String name;
 
@@ -54,5 +54,16 @@ public class WxCpUserDetail implements Serializable {
    */
   @SerializedName("qr_code")
   private String qrCode;
+
+  /**
+   * 企业邮箱，仅在用户同意snsapi_privateinfo授权时返回，2022年6月20号后的新应用将返回
+   */
+  @SerializedName("biz_mail")
+  private String bizMail;
+
+  /**
+   * 企业邮箱，仅在用户同意snsapi_privateinfo授权时返回，2022年6月20号后的新应用将返回
+   */
+  private String address;
 
 }


### PR DESCRIPTION
微信接口改动：
- [获取访问用户敏感信息](https://developer.work.weixin.qq.com/document/path/95833)，接口1
- [读取成员](https://developer.work.weixin.qq.com/document/path/90196)，接口2

如果新旧应用一起混用的话需要特别注意，类似：
- `name`字段，旧的应用`接口1`中可以正常获取，新的应用则没有此字段了，但`接口2`中新旧都有，所以统一去`接口2`中获取比较好
- `address`字段，旧的应用`接口1`中没有，`接口2`中有，新的应用`接口1`中有，`接口2`中没有，这时如果无法区分新旧应用则需要两个接口都要判定下，才能取到正确的值。
- 其它的字段是否还有这种情况则不是很清楚