### PR TITLE
【公众号】模板消息行业枚举”其它“错误

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/template/WxMpTemplateIndustryEnum.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/template/WxMpTemplateIndustryEnum.java
@@ -175,9 +175,9 @@ public enum WxMpTemplateIndustryEnum {
    */
   PRINTING("印刷", "印刷", 40),
   /**
-   * 其它 - 其它
+   * 其他 - 其他
    */
-  OTHER("其它", "其它", 41);
+  OTHER("其他", "其他", 41);
 
   /**
    * 主行业（一级行业）


### PR DESCRIPTION
文档中用的是”其它“，但是页面设置和接口返回的都是”其他“，所以导致toJson是找不到对应的枚举。