### PR TITLE
:art: 【公众号】菜单查询接口的返回结果增加缺失的 mediaId 和 articleId 字段

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/menu/WxMpSelfMenuInfo.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/menu/WxMpSelfMenuInfo.java
@@ -81,6 +81,22 @@ public class WxMpSelfMenuInfo implements Serializable {
     private String value;
 
     /**
+     * 调用新增永久素材接口返回的合法media_id
+     * <p>
+     * media_id类型和view_limited类型必须
+     */
+    @SerializedName("media_id")
+    private String mediaId;
+
+    /**
+     * 发布后获得的合法article_id
+     * <p>
+     * article_id类型和article_view_limited类型必须
+     */
+    @SerializedName("article_id")
+    private String articleId;
+
+    /**
      * <pre>
      * 小程序的appid.
      * miniprogram类型必须


### PR DESCRIPTION
公众号的菜单查询接口有两个：[接口1](https://developers.weixin.qq.com/doc/offiaccount/Custom_Menus/Querying_Custom_Menus.html "接口1") 和 [接口2](https://developers.weixin.qq.com/doc/offiaccount/Custom_Menus/Getting_Custom_Menu_Configurations.html "接口2")，框架里对前者的返回结果`WxMpSelfMenuInfo`，缺少`mediaId`（针对`media_id`类型的菜单）和 `articleId` 字段（针对`article_id`类型的菜单）。估计是作者忘记改了，我给加上了。