### PR TITLE
【小程序】修改使用okhttp及jodd创建直播间报错问题

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/jodd/JoddHttpSimplePostRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/jodd/JoddHttpSimplePostRequestExecutor.java
@@ -4,7 +4,6 @@ import jodd.http.HttpConnectionProvider;
 import jodd.http.HttpRequest;
 import jodd.http.HttpResponse;
 import jodd.http.ProxyInfo;
-import jodd.util.StringPool;
 import me.chanjar.weixin.common.enums.WxType;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.common.util.http.RequestHttp;
@@ -35,6 +34,7 @@ public class JoddHttpSimplePostRequestExecutor extends SimplePostRequestExecutor
     }
     request.withConnectionProvider(provider);
     if (postEntity != null) {
+      request.contentType("application/json", "utf-8");
       request.bodyText(postEntity);
     }
     HttpResponse response = request.send();

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/okhttp/OkHttpSimplePostRequestExecutor.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/okhttp/OkHttpSimplePostRequestExecutor.java
@@ -24,7 +24,7 @@ public class OkHttpSimplePostRequestExecutor extends SimplePostRequestExecutor<O
 
   @Override
   public String execute(String uri, String postEntity, WxType wxType) throws WxErrorException, IOException {
-    RequestBody body = RequestBody.Companion.create(postEntity, MediaType.parse("text/plain; charset=utf-8"));
+    RequestBody body = RequestBody.Companion.create(postEntity, MediaType.parse("application/json; charset=utf-8"));
     Request request = new Request.Builder().url(uri).post(body).build();
     Response response = requestHttp.getRequestHttpClient().newCall(request).execute();
     return this.handleResponse(wxType, Objects.requireNonNull(response.body()).string());

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaLiveServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaLiveServiceImplTest.java
@@ -40,14 +40,14 @@ public class WxMaLiveServiceImplTest {
     roomInfo.setName("订阅通知直播间");
     roomInfo.setCoverImg(mediaUpload.getMediaId());
     Calendar c = Calendar.getInstance();
-    c.set(2020, Calendar.DECEMBER, 10, 8, 0);
+    c.set(2023, Calendar.FEBRUARY, 10, 8, 0);
     roomInfo.setStartTime(c.getTimeInMillis() / 1000);
-    c.set(2020, Calendar.DECEMBER, 10, 12, 0);
+    c.set(2023, Calendar.FEBRUARY, 10, 12, 0);
     roomInfo.setEndTime(c.getTimeInMillis() / 1000);
     roomInfo.setAnchorName("鹏军_专业小程序开发");
     roomInfo.setAnchorWechat("pengjun939961241");
-    roomInfo.setCreaterWechat("pengjun939961241");
     roomInfo.setShareImg(mediaUpload.getMediaId());
+    roomInfo.setFeedsImg(mediaUpload.getMediaId());
     roomInfo.setType(1);
     roomInfo.setScreenType(1);
     roomInfo.setCloseLike(0);


### PR DESCRIPTION
使用okhttp及jodd创建直播间时, 会因为content-type不是application/json报错.
【错误信息】：错误代码：200002, 错误信息：parameter shareImg must no be null rid: 63c8bb21-2d921798-01463f21，微信原始报文：{"errmsg":"parameter shareImg must no be null rid: 63c8bb21-2d921798-01463f21","errcode":200002}
