### PR TITLE
企业微信：新增企业微信服务商的帐号ID转换接口

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpConvertTmpExternalUserIdResult.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpConvertTmpExternalUserIdResult.java
@@ -1,0 +1,41 @@
+package me.chanjar.weixin.cp.bean;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.util.List;
+
+@Setter
+@Getter
+public class WxCpTpConvertTmpExternalUserIdResult extends WxCpBaseResp {
+
+
+  @SerializedName("invalid_tmp_external_userid_list")
+  private List<Results> results;
+
+  @Getter
+  @Setter
+  public static class Results {
+
+    @SerializedName("tmp_external_userid")
+    private String tmpExternalUserId;
+
+    @SerializedName("external_userid")
+    private String externalUserId;
+
+    @SerializedName("corpid")
+    private String corpId;
+
+    @SerializedName("userid")
+    private String userId;
+  }
+
+  @SerializedName("invalid_tmp_external_userid_list")
+  private List<String> invalidTmpExternalUserIdList;
+
+  public static WxCpTpConvertTmpExternalUserIdResult fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpTpConvertTmpExternalUserIdResult.class);
+  }
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpOpenKfIdConvertResult.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpOpenKfIdConvertResult.java
@@ -1,0 +1,46 @@
+package me.chanjar.weixin.cp.bean;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.util.List;
+
+@Setter
+@Getter
+public class WxCpTpOpenKfIdConvertResult extends WxCpBaseResp {
+
+  /**
+   * 微信客服ID转换结果
+   */
+  @SerializedName("items")
+  private List<Item> items;
+
+  /**
+   * 无法转换的微信客服ID列表
+   */
+  @SerializedName("invalid_open_kfid_list")
+  private List<String> invalidOpenKfIdList;
+
+  @Getter
+  @Setter
+  public static class Item {
+
+    /***
+     * 企业主体下的微信客服ID
+     */
+    @SerializedName("open_kfid")
+    private String openKfId;
+
+    /**
+     * 服务商主体下的微信客服ID，如果传入的open_kfid已经是服务商主体下的ID，则new_open_kfid与open_kfid相同。
+     */
+    @SerializedName("new_open_kfid")
+    private String newOpenKfId;
+  }
+
+  public static WxCpTpOpenKfIdConvertResult fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpTpOpenKfIdConvertResult.class);
+  }
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpTagIdListConvertResult.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpTpTagIdListConvertResult.java
@@ -1,0 +1,51 @@
+package me.chanjar.weixin.cp.bean;
+
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class WxCpTpTagIdListConvertResult extends WxCpBaseResp {
+
+  private static final long serialVersionUID = -6153589164415497369L;
+
+
+  /**
+   * 客户标签转换结果
+   */
+  @SerializedName("items")
+  private List<Item> items;
+
+  /**
+   * 无法转换的客户标签ID列表
+   */
+  @SerializedName("invalid_external_tagid_list")
+  private List<String> invalidExternalTagIdList;
+
+
+  @Getter
+  @Setter
+  public static class Item {
+
+    /**
+     * 企业主体下的客户标签ID
+     */
+    @SerializedName("external_tagid")
+    private String externalTagId;
+
+    /**
+     * 服务商主体下的客户标签ID，如果传入的external_tagid已经是服务商主体下的ID，则open_external_tagid与external_tagid相同。
+     */
+    @SerializedName("open_external_tagid")
+    private String openExternalTagId;
+  }
+
+  public static WxCpTpTagIdListConvertResult fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpTpTagIdListConvertResult.class);
+  }
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -1451,4 +1451,28 @@ public interface WxCpApiPathConsts {
      */
     String SENG_MESSAGE="/cgi-bin/linkedcorp/message/send";
   }
+
+  interface IdConvert {
+
+    /**
+     * 将企业主体下的客户标签ID转换成服务商主体下的客户标签ID。
+     */
+    String EXTERNAL_TAG_ID = "/cgi-bin/idconvert/external_tagid";
+
+    /**
+     * 将微信客户的unionid转为第三方主体的external_userid
+     * 该接口有调用频率限制，当subject_type为0时，按企业作如下的限制：10万次/小时、48万次/天、750万次/月
+     */
+    String UNION_ID_TO_EXTERNAL_USER_ID = "/cgi-bin/idconvert/unionid_to_external_userid";
+
+    /**
+     * 将企业主体下的微信客服ID转换成服务商主体下的微信客服ID
+     */
+    String OPEN_KF_ID = "/cgi-bin/idconvert/open_kfid";
+
+    /**
+     * 将应用获取的外部用户临时idtmp_external_userid，转换为external_userid。
+     */
+    String CONVERT_TMP_EXTERNAL_USER_ID = "/cgi-bin/idconvert/convert_tmp_external_userid";
+  }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/tp/service/WxCpTpIdConvertService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/tp/service/WxCpTpIdConvertService.java
@@ -1,7 +1,12 @@
 package me.chanjar.weixin.cp.tp.service;
 
 import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.cp.bean.WxCpTpConvertTmpExternalUserIdResult;
+import me.chanjar.weixin.cp.bean.WxCpTpOpenKfIdConvertResult;
+import me.chanjar.weixin.cp.bean.WxCpTpTagIdListConvertResult;
 import me.chanjar.weixin.cp.bean.WxCpTpUnionidToExternalUseridResult;
+
+import java.util.List;
 
 /**
  * <pre>
@@ -25,4 +30,32 @@ public interface WxCpTpIdConvertService {
   WxCpTpUnionidToExternalUseridResult unionidToExternalUserid(String cropId, String unionid, String openid,
                                                               Integer subjectType) throws WxErrorException;
 
+
+  /**
+   * 将企业主体下的客户标签ID转换成服务商主体下的客户标签ID
+   * @param corpId             企业微信 ID
+   * @param externalTagIdList  企业主体下的客户标签ID列表，最多不超过1000个
+   * @return                    客户标签转换结果
+   * @throws WxErrorException .
+   */
+  WxCpTpTagIdListConvertResult externalTagId(String corpId, String... externalTagIdList) throws WxErrorException;
+
+  /**
+   * 将企业主体下的微信客服ID转换成服务商主体下的微信客服ID
+   * @param corpId             企业微信 ID
+   * @param openKfIdList       微信客服ID列表，最多不超过1000个
+   * @return                   微信客服ID转换结果
+   * @throws WxErrorException  .
+   */
+  WxCpTpOpenKfIdConvertResult ConvertOpenKfId (String corpId, String... openKfIdList ) throws WxErrorException;
+
+  /**
+   * 将应用获取的外部用户临时idtmp_external_userid，转换为external_userid
+   * @param corpId                 企业微信Id
+   * @param businessType           业务类型。1-会议 2-收集表
+   * @param userType               转换的目标用户类型。1-客户 2-企业互联 3-上下游 4-互联企业（圈子）
+   * @param tmpExternalUserIdList  外部用户临时id，最多不超过100个
+   * @return                       转换成功的结果列表
+   */
+  WxCpTpConvertTmpExternalUserIdResult convertTmpExternalUserId(String corpId, int businessType, int userType, String... tmpExternalUserIdList) throws WxErrorException;
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/tp/service/impl/WxCpTpIdConvertServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/tp/service/impl/WxCpTpIdConvertServiceImpl.java
@@ -1,12 +1,20 @@
 package me.chanjar.weixin.cp.tp.service.impl;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import lombok.RequiredArgsConstructor;
 import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.cp.bean.WxCpTpConvertTmpExternalUserIdResult;
+import me.chanjar.weixin.cp.bean.WxCpTpOpenKfIdConvertResult;
+import me.chanjar.weixin.cp.bean.WxCpTpTagIdListConvertResult;
 import me.chanjar.weixin.cp.bean.WxCpTpUnionidToExternalUseridResult;
 import me.chanjar.weixin.cp.config.WxCpTpConfigStorage;
+import me.chanjar.weixin.cp.constant.WxCpApiPathConsts;
 import me.chanjar.weixin.cp.tp.service.WxCpTpIdConvertService;
 import me.chanjar.weixin.cp.tp.service.WxCpTpService;
+
+import java.util.List;
 
 
 /**
@@ -26,10 +34,56 @@ public class WxCpTpIdConvertServiceImpl implements WxCpTpIdConvertService {
     }
     WxCpTpConfigStorage wxCpTpConfigStorage = mainService.getWxCpTpConfigStorage();
     String accessToken = wxCpTpConfigStorage.getAccessToken(cropId);
-    String url = wxCpTpConfigStorage.getApiUrl("/cgi-bin/idconvert/unionid_to_external_userid");
+    String url = wxCpTpConfigStorage.getApiUrl(WxCpApiPathConsts.IdConvert.UNION_ID_TO_EXTERNAL_USER_ID);
     url += "?access_token=" + accessToken;
     String responseContent = this.mainService.post(url, json.toString());
     return WxCpTpUnionidToExternalUseridResult.fromJson(responseContent);
+  }
+
+  @Override
+  public WxCpTpTagIdListConvertResult externalTagId(String corpId, String... externalTagIdList) throws WxErrorException {
+    WxCpTpConfigStorage wxCpTpConfigStorage = mainService.getWxCpTpConfigStorage();
+    String url = wxCpTpConfigStorage.getApiUrl(WxCpApiPathConsts.IdConvert.EXTERNAL_TAG_ID ) + "?access_token=" + mainService.getWxCpTpConfigStorage().getAccessToken(corpId);
+
+    JsonObject jsonObject = new JsonObject();
+    JsonArray jsonArray = new JsonArray();
+    for (String tagId : externalTagIdList) {
+      jsonArray.add(new JsonPrimitive(tagId));
+    }
+    jsonObject.add("external_tagid_list", jsonArray);
+    String responseContent = this.mainService.post(url, jsonObject.toString());
+
+    return WxCpTpTagIdListConvertResult.fromJson(responseContent);
+  }
+
+  @Override
+  public WxCpTpOpenKfIdConvertResult ConvertOpenKfId(String corpId, String... openKfIdList) throws WxErrorException {
+    WxCpTpConfigStorage wxCpTpConfigStorage = mainService.getWxCpTpConfigStorage();
+    String url = wxCpTpConfigStorage.getApiUrl(WxCpApiPathConsts.IdConvert.OPEN_KF_ID + "?access_token=" + mainService.getWxCpTpConfigStorage().getAccessToken(corpId));
+    JsonObject jsonObject = new JsonObject();
+    JsonArray jsonArray = new JsonArray();
+    for (String kfId : openKfIdList) {
+      jsonArray.add(new JsonPrimitive(kfId));
+    }
+    jsonObject.add("open_kfid_list", jsonArray);
+    String responseContent = this.mainService.post(url, jsonObject.toString());
+    return WxCpTpOpenKfIdConvertResult.fromJson(responseContent);
+  }
+
+  @Override
+  public WxCpTpConvertTmpExternalUserIdResult convertTmpExternalUserId(String corpId, int businessType, int userType, String... tmpExternalUserIdList) throws WxErrorException {
+    WxCpTpConfigStorage wxCpTpConfigStorage = mainService.getWxCpTpConfigStorage();
+    String url = wxCpTpConfigStorage.getApiUrl(WxCpApiPathConsts.IdConvert.CONVERT_TMP_EXTERNAL_USER_ID + "?access_token=" + mainService.getWxCpTpConfigStorage().getAccessToken(corpId));
+    JsonObject jsonObject = new JsonObject();
+    JsonArray jsonArray = new JsonArray();
+    jsonObject.addProperty("business_type", businessType);
+    jsonObject.addProperty("user_type", userType);
+    for (String userId : tmpExternalUserIdList) {
+      jsonArray.add(new JsonPrimitive(userId));
+    }
+    jsonObject.add("tmp_external_userid_list", jsonArray);
+    String responseContent = mainService.post(url, jsonObject.toString());
+    return WxCpTpConvertTmpExternalUserIdResult.fromJson(responseContent);
   }
 
 


### PR DESCRIPTION
[企业微信服务商开发文档](https://developer.work.weixin.qq.com/document/path/96169)

新增：将企业主体下的[客户标签ID](https://developer.work.weixin.qq.com/document/path/96169#17298)转换成服务商主体下的客户标签ID
新增：将企业主体下的[微信客服ID](https://developer.work.weixin.qq.com/document/path/97064#31139)转换成服务商主体下的微信客服ID。
新增：将应用获取的外部用户临时idtmp_external_userid，转换为external_userid。