### PR TITLE
1.修复bug:小程序获取url link的请求封装类GenerateUrlLinkRequest中expireTime属性应为Long，…

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/urllink/GenerateUrlLinkRequest.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/urllink/GenerateUrlLinkRequest.java
@@ -74,7 +74,7 @@ public class GenerateUrlLinkRequest implements Serializable {
    * </pre>
    */
   @SerializedName("expire_time")
-  private Integer expireTime;
+  private Long expireTime;
 
   /**
    * 到期失效的URL Link的失效间隔天数。生成的到期失效URL Link在该间隔时间到达前有效。最长间隔天数为365天。expire_type 为 1 必填

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaLinkServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaLinkServiceImplTest.java
@@ -10,6 +10,9 @@ import me.chanjar.weixin.common.error.WxErrorException;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 @Test
 @Guice(modules = ApiTestModule.class)
 @Slf4j
@@ -21,6 +24,7 @@ public class WxMaLinkServiceImplTest {
   public void testGenerateUrlLink() throws WxErrorException {
     String url = this.wxMaService.getLinkService().generateUrlLink(GenerateUrlLinkRequest.builder()
       .path("pages/tabBar/home/home")
+      .expireTime(LocalDateTime.now().plusDays(5).atZone(ZoneId.systemDefault()).toEpochSecond()) //增加有效期，此行可注释
       .build());
 
     System.out.println(url);


### PR DESCRIPTION
…现在是Integer

2.针对修复的bug 单元测试增加expireTime逻辑；

官方链接说明：https://developers.weixin.qq.com/miniprogram/dev/OpenApiDoc/qrcode-link/url-link/queryUrlLink.html github issues:https://github.com/Wechat-Group/WxJava/issues/2973