### PR TITLE
:bug: fix 企业微信新增外部联系人回调去重错误问题

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/tp/message/WxCpTpMessageRouter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/tp/message/WxCpTpMessageRouter.java
@@ -273,7 +273,8 @@ public class WxCpTpMessageRouter {
         .append("-").append(StringUtils.trimToEmpty(wxMessage.getAuthCorpId()))
         .append("-").append(StringUtils.trimToEmpty(wxMessage.getUserID()))
         .append("-").append(StringUtils.trimToEmpty(wxMessage.getChangeType()))
-        .append("-").append(StringUtils.trimToEmpty(wxMessage.getServiceCorpId()));
+        .append("-").append(StringUtils.trimToEmpty(wxMessage.getServiceCorpId()))
+        .append("-").append(StringUtils.trimToEmpty(wxMessage.getExternalUserID()));
     }
 
     if (wxMessage.getMsgType() != null) {


### PR DESCRIPTION
企业微信回调  新增外部联系人事件，同一时间回调的情况下（微信回调的timeStamp以秒为单位，同一秒的同一userId添加的联系人备去重了）回调信息中 除了 externalUserID其他都一致，需要在去重规则中加上检验externalUserID