### PR TITLE
【小程序/公众号】提供了更新access_token的消费接口

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxAccessTokenEntity.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxAccessTokenEntity.java
@@ -6,10 +6,9 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
+ * token
+ *
  * @author cn
- * @version 1.0
- * @description
- * @date 2023/3/27 18:34
  */
 @Getter
 @Setter

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxAccessTokenEntity.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxAccessTokenEntity.java
@@ -1,0 +1,20 @@
+package me.chanjar.weixin.common.bean;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * @author cn
+ * @version 1.0
+ * @description
+ * @date 2023/3/27 18:34
+ */
+@Getter
+@Setter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class WxAccessTokenEntity extends WxAccessToken {
+  private String appid;
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/BaseWxMaServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/BaseWxMaServiceImpl.java
@@ -324,7 +324,7 @@ public abstract class BaseWxMaServiceImpl<H, P> implements WxMaService, RequestH
       throw new WxErrorException(error);
     }
     WxAccessToken accessToken = WxAccessToken.fromJson(resultContent);
-    config.updateAccessToken(accessToken.getAccessToken(), accessToken.getExpiresIn());
+    config.updateAccessTokenProcessor(accessToken.getAccessToken(), accessToken.getExpiresIn());
     return accessToken.getAccessToken();
   }
 

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/WxMaConfig.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/WxMaConfig.java
@@ -5,6 +5,7 @@ import me.chanjar.weixin.common.bean.WxAccessTokenEntity;
 import me.chanjar.weixin.common.util.http.apache.ApacheHttpClientBuilder;
 
 import java.util.concurrent.locks.Lock;
+import java.util.function.Consumer;
 
 /**
  * 小程序配置
@@ -12,6 +13,10 @@ import java.util.concurrent.locks.Lock;
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
 public interface WxMaConfig {
+
+  default void setUpdateAccessTokenBefore(Consumer<WxAccessTokenEntity> updateAccessTokenBefore) {
+
+  }
 
   /**
    * Gets access token.

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/WxMaConfig.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/WxMaConfig.java
@@ -1,6 +1,7 @@
 package cn.binarywang.wx.miniapp.config;
 
 import me.chanjar.weixin.common.bean.WxAccessToken;
+import me.chanjar.weixin.common.bean.WxAccessTokenEntity;
 import me.chanjar.weixin.common.util.http.apache.ApacheHttpClientBuilder;
 
 import java.util.concurrent.locks.Lock;
@@ -43,7 +44,9 @@ public interface WxMaConfig {
    *
    * @param accessToken 要更新的WxAccessToken对象
    */
-  void updateAccessToken(WxAccessToken accessToken);
+  default void updateAccessToken(WxAccessToken accessToken) {
+    updateAccessToken(accessToken.getAccessToken(), accessToken.getExpiresIn());
+  }
 
   /**
    * 应该是线程安全的
@@ -52,6 +55,20 @@ public interface WxMaConfig {
    * @param expiresInSeconds 过期时间，以秒为单位
    */
   void updateAccessToken(String accessToken, int expiresInSeconds);
+
+  default void updateAccessTokenProcessor(String accessToken, int expiresInSeconds) {
+    WxAccessTokenEntity wxAccessTokenEntity = new WxAccessTokenEntity();
+    wxAccessTokenEntity.setAppid(getAppid());
+    wxAccessTokenEntity.setAccessToken(accessToken);
+    wxAccessTokenEntity.setExpiresIn(expiresInSeconds);
+    updateAccessTokenBefore(wxAccessTokenEntity);
+    updateAccessToken(accessToken, expiresInSeconds);
+  }
+
+  default void updateAccessTokenBefore(WxAccessTokenEntity wxAccessTokenEntity) {
+
+  }
+
 
   /**
    * Gets jsapi ticket.

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/impl/WxMaDefaultConfigImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/impl/WxMaDefaultConfigImpl.java
@@ -2,13 +2,16 @@ package cn.binarywang.wx.miniapp.config.impl;
 
 import cn.binarywang.wx.miniapp.config.WxMaConfig;
 import cn.binarywang.wx.miniapp.json.WxMaGsonBuilder;
+import lombok.AccessLevel;
 import lombok.Getter;
-import me.chanjar.weixin.common.bean.WxAccessToken;
+import lombok.Setter;
+import me.chanjar.weixin.common.bean.WxAccessTokenEntity;
 import me.chanjar.weixin.common.util.http.apache.ApacheHttpClientBuilder;
 
 import java.io.File;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 /**
  * 基于内存的微信配置provider，在实际生产环境中应该将这些配置持久化
@@ -59,6 +62,23 @@ public class WxMaDefaultConfigImpl implements WxMaConfig {
   private String accessTokenUrl;
 
   /**
+   * 自定义配置token的消费者
+   */
+  @Setter
+  private Consumer<WxAccessTokenEntity> updateAccessTokenBefore;
+  @Getter(AccessLevel.NONE)
+  private boolean enableUpdateAccessTokenBefore = true;
+
+  /**
+   * 可临时关闭更新token回调，主要用于其他介质初始化数据时，可不进行回调
+   *
+   * @param enableUpdateAccessTokenBefore
+   */
+  public void enableUpdateAccessTokenBefore(boolean enableUpdateAccessTokenBefore) {
+    this.enableUpdateAccessTokenBefore = enableUpdateAccessTokenBefore;
+  }
+
+  /**
    * 会过期的数据提前过期时间，默认预留200秒的时间
    */
   protected long expiresAheadInMillis(int expiresInSeconds) {
@@ -95,15 +115,22 @@ public class WxMaDefaultConfigImpl implements WxMaConfig {
     return isExpired(this.expiresTime);
   }
 
-  @Override
-  public synchronized void updateAccessToken(WxAccessToken accessToken) {
-    updateAccessToken(accessToken.getAccessToken(), accessToken.getExpiresIn());
-  }
+//  @Override
+//  public synchronized void updateAccessToken(WxAccessToken accessToken) {
+//    updateAccessToken(accessToken.getAccessToken(), accessToken.getExpiresIn());
+//  }
 
   @Override
   public synchronized void updateAccessToken(String accessToken, int expiresInSeconds) {
     setAccessToken(accessToken);
     setExpiresTime(expiresAheadInMillis(expiresInSeconds));
+  }
+
+  @Override
+  public void updateAccessTokenBefore(WxAccessTokenEntity wxAccessTokenEntity) {
+    if (updateAccessTokenBefore != null && enableUpdateAccessTokenBefore) {
+      updateAccessTokenBefore.accept(wxAccessTokenEntity);
+    }
   }
 
   @Override

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/impl/WxMaDefaultConfigImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/impl/WxMaDefaultConfigImpl.java
@@ -66,13 +66,15 @@ public class WxMaDefaultConfigImpl implements WxMaConfig {
    */
   @Setter
   private Consumer<WxAccessTokenEntity> updateAccessTokenBefore;
+
+  /**
+   * 开启回调
+   */
   @Getter(AccessLevel.NONE)
   private boolean enableUpdateAccessTokenBefore = true;
 
   /**
    * 可临时关闭更新token回调，主要用于其他介质初始化数据时，可不进行回调
-   *
-   * @param enableUpdateAccessTokenBefore
    */
   public void enableUpdateAccessTokenBefore(boolean enableUpdateAccessTokenBefore) {
     this.enableUpdateAccessTokenBefore = enableUpdateAccessTokenBefore;

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/impl/WxMaRedissonConfigImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/config/impl/WxMaRedissonConfigImpl.java
@@ -91,7 +91,7 @@ public class WxMaRedissonConfigImpl extends WxMaDefaultConfigImpl {
 
   @Override
   public void updateAccessToken(WxAccessToken accessToken) {
-    redisOps.setValue(this.accessTokenKey, accessToken.getAccessToken(), accessToken.getExpiresIn(), TimeUnit.SECONDS);
+    updateAccessToken(accessToken.getAccessToken(), accessToken.getExpiresIn());
   }
 
   @Override

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImplTest.java
@@ -5,6 +5,7 @@ import cn.binarywang.wx.miniapp.config.WxMaConfig;
 import cn.binarywang.wx.miniapp.config.impl.WxMaDefaultConfigImpl;
 import cn.binarywang.wx.miniapp.test.ApiTestModule;
 import com.google.inject.Inject;
+import me.chanjar.weixin.common.bean.WxAccessTokenEntity;
 import me.chanjar.weixin.common.error.WxError;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.common.error.WxMpErrorMsgEnum;
@@ -44,14 +45,21 @@ public class WxMaServiceImplTest {
     assertTrue(StringUtils.isNotBlank(after));
   }
 
+  private void updateAccessTokenBefore(WxAccessTokenEntity wxAccessTokenEntity) {
+    System.out.println("token:" + wxAccessTokenEntity.toString());
+  }
+
   public void testTokenCallBack() throws WxErrorException {
     WxMaDefaultConfigImpl config = new WxMaDefaultConfigImpl();
     WxMaConfig configStorage = this.wxService.getWxMaConfig();
     config.setAppid(configStorage.getAppid());
     config.setSecret(configStorage.getSecret());
-    config.setUpdateAccessTokenBefore(e -> {
-      System.out.println("token:" + e.toString());
-    });
+//    //第一种方式
+//    config.setUpdateAccessTokenBefore(e -> {
+//      System.out.println("token:" + e.toString());
+//    });
+    //第二种方式
+    config.setUpdateAccessTokenBefore(this::updateAccessTokenBefore);
     this.wxService.setWxMaConfig(config);
 
     String before = config.getAccessToken();

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImplTest.java
@@ -44,6 +44,26 @@ public class WxMaServiceImplTest {
     assertTrue(StringUtils.isNotBlank(after));
   }
 
+  public void testTokenCallBack() throws WxErrorException {
+    WxMaDefaultConfigImpl config = new WxMaDefaultConfigImpl();
+    WxMaConfig configStorage = this.wxService.getWxMaConfig();
+    config.setAppid(configStorage.getAppid());
+    config.setSecret(configStorage.getSecret());
+    config.setUpdateAccessTokenBefore(e -> {
+      System.out.println("token:" + e.toString());
+    });
+    this.wxService.setWxMaConfig(config);
+
+    String before = config.getAccessToken();
+    this.wxService.getAccessToken(true);
+    String after = config.getAccessToken();
+    assertNotEquals(before, after);
+    assertTrue(StringUtils.isNotBlank(after));
+    config.enableUpdateAccessTokenBefore(false);
+    this.wxService.getAccessToken(true);
+    after = config.getAccessToken();
+    System.out.println(after);
+  }
   @Test(expectedExceptions = {WxErrorException.class})
   public void testGetPaidUnionId() throws WxErrorException {
     final String unionId = this.wxService.getPaidUnionId("1", null, "3", "4");
@@ -134,7 +154,7 @@ public class WxMaServiceImplTest {
     });
     try {
       Object execute = service.execute(re, "http://baidu.com", new HashMap<>());
-      Assert.assertTrue(false, "代码应该不会执行到这里");
+      Assert.fail("代码应该不会执行到这里");
     } catch (WxErrorException e) {
       Assert.assertEquals(WxMpErrorMsgEnum.CODE_40001.getCode(), e.getError().getErrorCode());
       Assert.assertEquals(2, counter.get());


### PR DESCRIPTION
**如何使用：**

1. 多个 appid 配置类，需要继承 `WxMaDefaultConfigImpl`；
2. 设置 `WxMaDefaultConfigImpl#setUpdateAccessTokenBefore` 的消费者: _例子：_

```java
  public void init() {
    WxMaDefaultConfigImpl config = new WxMaDefaultConfigImpl();
//     //第一种方式
//    config.setUpdateAccessTokenBefore(e -> {
//      System.out.println("token:" + e.toString());
//    });
    //第二种方式
    config.setUpdateAccessTokenBefore(this::updateAccessTokenBefore);
  }

  private void updateAccessTokenBefore(WxAccessTokenEntity wxAccessTokenEntity) {
    System.out.println("token:" + wxAccessTokenEntity.toString());
  }
```
3. 动态开启是否进行回调 `WxMaDefaultConfigImpl#enableUpdateAccessTokenBefore`，默认开启了回调