### PR TITLE
兼容SpringBoot3中使用的Jedis4版本

### DIFF
--- a/spring-boot-starters/wx-java-mp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/mp/config/WxMpStorageAutoConfiguration.java
+++ b/spring-boot-starters/wx-java-mp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/mp/config/WxMpStorageAutoConfiguration.java
@@ -14,16 +14,16 @@ import me.chanjar.weixin.mp.config.WxMpConfigStorage;
 import me.chanjar.weixin.mp.config.impl.WxMpDefaultConfigImpl;
 import me.chanjar.weixin.mp.config.impl.WxMpRedisConfigImpl;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.JedisPoolAbstract;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.util.Pool;
 
 import java.util.Set;
 
@@ -74,7 +74,7 @@ public class WxMpStorageAutoConfiguration {
   }
 
   private WxMpConfigStorage jedisConfigStorage() {
-    JedisPoolAbstract jedisPool;
+    Pool<Jedis> jedisPool;
     if (wxMpProperties.getConfigStorage() != null && wxMpProperties.getConfigStorage().getRedis() != null
       && StringUtils.isNotEmpty(wxMpProperties.getConfigStorage().getRedis().getHost())) {
       jedisPool = getJedisPool();
@@ -131,7 +131,7 @@ public class WxMpStorageAutoConfiguration {
     }
   }
 
-  private JedisPoolAbstract getJedisPool() {
+  private Pool<Jedis> getJedisPool() {
     RedisProperties redis = wxMpProperties.getConfigStorage().getRedis();
 
     JedisPoolConfig config = new JedisPoolConfig();


### PR DESCRIPTION
fix Caused by: java.lang.NoClassDefFoundError: redis/clients/jedis/JedisPoolAbstract
SpringBoot3 中默认使用Jedis4，无此class