### PR TITLE
bugfix: 修复WxMaCodeExtConfig类无法反序列化的问题

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/code/WxMaCodeExtConfig.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/code/WxMaCodeExtConfig.java
@@ -100,6 +100,8 @@ public class WxMaCodeExtConfig implements Serializable {
    */
   @Data
   @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class PageConfig implements Serializable {
     private static final long serialVersionUID = -8615574764987479723L;
     /**
@@ -148,6 +150,8 @@ public class WxMaCodeExtConfig implements Serializable {
    */
   @Data
   @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class TabBar implements Serializable {
     private static final long serialVersionUID = -3037016532526129399L;
 
@@ -181,6 +185,8 @@ public class WxMaCodeExtConfig implements Serializable {
      */
     @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Item implements Serializable {
       private static final long serialVersionUID = -5824322265161612460L;
       /**
@@ -207,6 +213,8 @@ public class WxMaCodeExtConfig implements Serializable {
    */
   @Data
   @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class NetworkTimeout implements Serializable {
     private static final long serialVersionUID = -9180176522015880991L;
 


### PR DESCRIPTION
WxMaCodeExtConfig类中的匿名内部类上添加了@Builder注解但未添加@NoArgsConstructor注解，导致Jackson无法反序列化。ps：lombok坑较多，建议去除