### PR TITLE
:fix: #3037 企业微信 第三方审批不同回调下实体缺少字段问题

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpTpXmlMessage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpTpXmlMessage.java
@@ -479,7 +479,7 @@ public class WxCpTpXmlMessage implements Serializable {
   private WxCpXmlMessage.SendLocationInfo sendLocationInfo = new WxCpXmlMessage.SendLocationInfo();
 
   @XStreamAlias("ApprovalInfo")
-  private ApprovalInfo approvalInfo = new ApprovalInfo();
+  private WxCpXmlApprovalInfo approvalInfo = new WxCpXmlApprovalInfo();
 
   @XStreamAlias("TaskId")
   @XStreamConverter(value = XStreamCDataConverter.class)
@@ -580,6 +580,7 @@ public class WxCpTpXmlMessage implements Serializable {
 
   /**
    * The type Approval info.
+   * @deprecated 无法同时适配不同回调下的实体字段，使用WxCpXmlApprovalInfo可完美适配
    */
   @Data
   @XStreamAlias("ApprovalInfo")


### PR DESCRIPTION
修改WxCpTpXmlMessage，弃用内部类ApprovalInfo ，使用WxCpXmlApprovalInfo ，以适配多种回调下的实体字段