### PR TITLE
【公众号】提供了获取稳定版获取access token的接口

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpServiceOkHttpImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpServiceOkHttpImpl.java
@@ -1,19 +1,17 @@
 package me.chanjar.weixin.mp.api.impl;
 
-import me.chanjar.weixin.common.error.WxErrorException;
-import me.chanjar.weixin.common.error.WxRuntimeException;
 import me.chanjar.weixin.common.util.http.HttpType;
 import me.chanjar.weixin.common.util.http.okhttp.DefaultOkHttpClientBuilder;
 import me.chanjar.weixin.common.util.http.okhttp.OkHttpProxyInfo;
+import me.chanjar.weixin.mp.bean.WxMpStableAccessTokenRequest;
 import me.chanjar.weixin.mp.config.WxMpConfigStorage;
 import okhttp3.*;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
 
 import static me.chanjar.weixin.mp.enums.WxMpApiUrl.Other.GET_ACCESS_TOKEN_URL;
+import static me.chanjar.weixin.mp.enums.WxMpApiUrl.Other.GET_STABLE_ACCESS_TOKEN_URL;
 
 /**
  * okhttp实现.
@@ -37,38 +35,6 @@ public class WxMpServiceOkHttpImpl extends BaseWxMpServiceImpl<OkHttpClient, OkH
   @Override
   public HttpType getRequestType() {
     return HttpType.OK_HTTP;
-  }
-
-  @Override
-  public String getAccessToken(boolean forceRefresh) throws WxErrorException {
-    final WxMpConfigStorage config = this.getWxMpConfigStorage();
-    if (!config.isAccessTokenExpired() && !forceRefresh) {
-      return config.getAccessToken();
-    }
-
-    Lock lock = config.getAccessTokenLock();
-    boolean locked = false;
-    try {
-      do {
-        locked = lock.tryLock(100, TimeUnit.MILLISECONDS);
-        if (!forceRefresh && !config.isAccessTokenExpired()) {
-          return config.getAccessToken();
-        }
-      } while (!locked);
-      String url = String.format(GET_ACCESS_TOKEN_URL.getUrl(config), config.getAppId(), config.getSecret());
-
-      Request request = new Request.Builder().url(url).get().build();
-      Response response = getRequestHttpClient().newCall(request).execute();
-      return this.extractAccessToken(Objects.requireNonNull(response.body()).string());
-    } catch (IOException e) {
-      throw new WxRuntimeException(e);
-    } catch (InterruptedException e) {
-      throw new WxRuntimeException(e);
-    } finally {
-      if (locked) {
-        lock.unlock();
-      }
-    }
   }
 
   @Override
@@ -99,4 +65,30 @@ public class WxMpServiceOkHttpImpl extends BaseWxMpServiceImpl<OkHttpClient, OkH
     }
   }
 
+  @Override
+  protected String doGetAccessTokenRequest() throws IOException {
+    String url = String.format(GET_ACCESS_TOKEN_URL.getUrl(getWxMpConfigStorage()), getWxMpConfigStorage().getAppId(), getWxMpConfigStorage().getSecret());
+
+    Request request = new Request.Builder().url(url).get().build();
+    try (Response response = getRequestHttpClient().newCall(request).execute()) {
+      return Objects.requireNonNull(response.body()).string();
+    }
+  }
+
+  @Override
+  protected String doGetStableAccessTokenRequest(boolean forceRefresh) throws IOException {
+    String url = GET_STABLE_ACCESS_TOKEN_URL.getUrl(getWxMpConfigStorage());
+
+    WxMpStableAccessTokenRequest wxMaAccessTokenRequest = new WxMpStableAccessTokenRequest();
+    wxMaAccessTokenRequest.setAppid(this.getWxMpConfigStorage().getAppId());
+    wxMaAccessTokenRequest.setSecret(this.getWxMpConfigStorage().getSecret());
+    wxMaAccessTokenRequest.setGrantType("client_credential");
+    wxMaAccessTokenRequest.setForceRefresh(forceRefresh);
+
+    RequestBody body = RequestBody.Companion.create(wxMaAccessTokenRequest.toJson(), MediaType.parse("application/json; charset=utf-8"));
+    Request request = new Request.Builder().url(url).post(body).build();
+    try (Response response = getRequestHttpClient().newCall(request).execute()) {
+      return Objects.requireNonNull(response.body()).string();
+    }
+  }
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpStableAccessTokenRequest.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/WxMpStableAccessTokenRequest.java
@@ -1,0 +1,32 @@
+package me.chanjar.weixin.mp.bean;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import me.chanjar.weixin.mp.util.json.WxMpGsonBuilder;
+
+import java.io.Serializable;
+
+/**
+ * @author SKYhuangjing
+ * 微信公众号 获取稳定版接口调用凭据 请求参数
+ */
+@Data
+public class WxMpStableAccessTokenRequest implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @SerializedName("grant_type")
+  private String grantType = "client_credential";
+
+  @SerializedName("appid")
+  private String appid;
+  @SerializedName("secret")
+  private String secret;
+
+  @SerializedName("force_refresh")
+  private boolean forceRefresh;
+
+  public String toJson() {
+    return WxMpGsonBuilder.create().toJson(this);
+  }
+}

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/config/WxMpConfigStorage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/config/WxMpConfigStorage.java
@@ -21,6 +21,19 @@ public interface WxMpConfigStorage {
   String getAccessToken();
 
   /**
+   * Is use stable access token api
+   * @Link https://developers.weixin.qq.com/doc/offiaccount/Basic_Information/getStableAccessToken.html
+   * @return the boolean
+   */
+  boolean isStableAccessToken();
+
+  /**
+   * Set use stable access token api
+   * @param useStableAccessToken true is use, false is not
+   */
+  void useStableAccessToken(boolean useStableAccessToken);
+
+  /**
    * Gets access token lock.
    *
    * @return the access token lock

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/config/impl/WxMpDefaultConfigImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/config/impl/WxMpDefaultConfigImpl.java
@@ -24,6 +24,10 @@ public class WxMpDefaultConfigImpl implements WxMpConfigStorage, Serializable {
 
   protected volatile String appId;
   protected volatile String secret;
+  /**
+   * 是否使用稳定版 Access Token
+   */
+  private boolean useStableAccessToken;
   protected volatile String token;
   protected volatile String templateId;
   protected volatile String accessToken;
@@ -59,6 +63,16 @@ public class WxMpDefaultConfigImpl implements WxMpConfigStorage, Serializable {
   protected volatile ApacheHttpClientBuilder apacheHttpClientBuilder;
 
   private WxMpHostConfig hostConfig = null;
+
+  @Override
+  public boolean isStableAccessToken() {
+    return this.useStableAccessToken;
+  }
+
+  @Override
+  public void useStableAccessToken(boolean useStableAccessToken) {
+    this.useStableAccessToken = useStableAccessToken;
+  }
 
   @Override
   public boolean isAccessTokenExpired() {

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/enums/WxMpApiUrl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/enums/WxMpApiUrl.java
@@ -130,6 +130,10 @@ public interface WxMpApiUrl {
      */
     GET_ACCESS_TOKEN_URL(API_DEFAULT_HOST_URL, "/cgi-bin/token?grant_type=client_credential&appid=%s&secret=%s"),
     /**
+     * 获取稳定版 access_token.
+     */
+    GET_STABLE_ACCESS_TOKEN_URL(API_DEFAULT_HOST_URL, "/cgi-bin/stable_token"),
+    /**
      * 获得各种类型的ticket.
      */
     GET_TICKET_URL(API_DEFAULT_HOST_URL, "/cgi-bin/ticket/getticket?type="),

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImplTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImplTest.java
@@ -212,6 +212,16 @@ public class BaseWxMpServiceImplTest {
       }
 
       @Override
+      protected String doGetAccessTokenRequest() throws IOException {
+        return null;
+      }
+
+      @Override
+      protected String doGetStableAccessTokenRequest(boolean forceRefresh) throws IOException {
+        return null;
+      }
+
+      @Override
       public void initHttp() {
 
       }

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/WxMpServiceImplTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/WxMpServiceImplTest.java
@@ -59,4 +59,15 @@ public class WxMpServiceImplTest {
     Assert.assertNotEquals(before, after);
     Assert.assertTrue(StringUtils.isNotBlank(after));
   }
+
+  public void testStableRefreshAccessToken() throws WxErrorException {
+    WxMpConfigStorage configStorage = this.wxService.getWxMpConfigStorage();
+    configStorage.useStableAccessToken(true);
+    String before = configStorage.getAccessToken();
+    this.wxService.getAccessToken(false);
+
+    String after = configStorage.getAccessToken();
+    Assert.assertNotEquals(before, after);
+    Assert.assertTrue(StringUtils.isNotBlank(after));
+  }
 }


### PR DESCRIPTION
参考  PR #3004 移植支持 公众号获取access token的接口

如何使用
直接配置类 WxMpConfigStorage#useStableAccessToken 开启使用稳定版获取access_token接口，默认未开启