### PR TITLE
Update WxPayApplyment4SubCreateRequest.java

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/applyment/WxPayApplyment4SubCreateRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/applyment/WxPayApplyment4SubCreateRequest.java
@@ -1095,6 +1095,18 @@ public class WxPayApplyment4SubCreateRequest implements Serializable {
     private String activitiesRate;
 
     /**
+     * 非信用卡活动费率值
+     */
+    @SerializedName("debit_activities_rate")
+    private String debitActivitiesRate;
+
+    /**
+     * 信用卡活动费率值
+     */
+    @SerializedName("credit_activities_rate")
+    private String creditActivitiesRate;
+
+    /**
      * 优惠费率活动补充材料
      */
     @SerializedName("activities_additions")


### PR DESCRIPTION
2023年7月17日-9月17日 能够使用activities_rate参数传入活动费率，9月17日后如果需要传入费率必须使用debit_activities_rate和credit_activities_rate这2个参数分开填写。