### PR TITLE
初始化v3客户端时，未设置证书序列号值才尝试加载证书

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/v3/ProfitSharingReceiver.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/v3/ProfitSharingReceiver.java
@@ -46,6 +46,16 @@ public class ProfitSharingReceiver implements Serializable {
 
   /**
    * <pre>
+   * 字段名：子商户应用ID
+   * 是否必填：否
+   * 描述：子商户的公众账号ID，分账接收方类型包含PERSONAL_SUB_OPENID时必填
+   * </pre>
+   */
+  @SerializedName("sub_appid")
+  private String subAppid;
+
+  /**
+   * <pre>
    * 字段名：分账接收方类型
    * 是否必填：是
    * 描述：

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/v3/ProfitSharingRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/v3/ProfitSharingRequest.java
@@ -46,6 +46,16 @@ public class ProfitSharingRequest implements Serializable {
 
   /**
    * <pre>
+   * 字段名：子商户应用ID
+   * 是否必填：否
+   * 描述：子商户的公众账号ID，分账接收方类型包含PERSONAL_SUB_OPENID时必填
+   * </pre>
+   */
+  @SerializedName("sub_appid")
+  private String subAppid;
+
+  /**
+   * <pre>
    * 字段名：微信订单号
    * 是否必填：是
    * 描述：微信支付订单号

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -262,12 +262,12 @@ public class WxPayConfig {
 
     InputStream keyInputStream = this.loadConfigInputStream(this.getPrivateKeyString(), this.getPrivateKeyPath(),
       this.privateKeyContent, "privateKeyPath");
-    InputStream certInputStream = this.loadConfigInputStream(this.getPrivateCertString(), this.getPrivateCertPath(),
-      this.privateCertContent, "privateCertPath");
     try {
       PrivateKey merchantPrivateKey = PemUtils.loadPrivateKey(keyInputStream);
-      X509Certificate certificate = PemUtils.loadCertificate(certInputStream);
       if (StringUtils.isBlank(this.getCertSerialNo())) {
+        InputStream certInputStream = this.loadConfigInputStream(this.getPrivateCertString(), this.getPrivateCertPath(),
+          this.privateCertContent, "privateCertPath");
+        X509Certificate certificate = PemUtils.loadCertificate(certInputStream);
         this.certSerialNo = certificate.getSerialNumber().toString(16).toUpperCase();
       }
       //构造Http Proxy正向代理
@@ -290,6 +290,8 @@ public class WxPayConfig {
       this.privateKey = merchantPrivateKey;
 
       return httpClient;
+    } catch (WxPayException e) {
+      throw e;
     } catch (Exception e) {
       throw new WxPayException("v3请求构造异常！", e);
     }


### PR DESCRIPTION
目前即使对 `WxPayConfig` 设置了 `certSerialNo` 属性还是会去加载证书，有时候项目中只要配置一下证书序列号值就行了