### PR TITLE
公众号订阅通知下发返回消息id

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpSubscribeMsgService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpSubscribeMsgService.java
@@ -134,8 +134,9 @@ public interface WxMpSubscribeMsgService {
      * </pre>
      *
      * @param subscribeMessage 订阅消息
+     * @return 下发消息id，与下发结果回调的msgId对应
      * @throws WxErrorException .
      */
-    void send(WxMpSubscribeMessage subscribeMessage) throws WxErrorException;
+    String send(WxMpSubscribeMessage subscribeMessage) throws WxErrorException;
 
 }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpSubscribeMsgServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpSubscribeMsgServiceImpl.java
@@ -103,11 +103,12 @@ public class WxMpSubscribeMsgServiceImpl implements WxMpSubscribeMsgService {
   }
 
   @Override
-  public void send(WxMpSubscribeMessage subscribeMessage) throws WxErrorException {
+  public String send(WxMpSubscribeMessage subscribeMessage) throws WxErrorException {
     String responseContent = this.service.post(SEND_SUBSCRIBE_MESSAGE_URL, subscribeMessage.toJson());
     JsonObject jsonObject = GsonParser.parse(responseContent);
     if (jsonObject.get(ERR_CODE).getAsInt() != 0) {
       throw new WxErrorException(WxError.fromJson(responseContent, WxType.MP));
     }
+    return jsonObject.get("msgid").getAsString();
   }
 }


### PR DESCRIPTION
根据微信[接口文档](https://developers.weixin.qq.com/doc/offiaccount/Subscription_Messages/api.html#send%E5%8F%91%E9%80%81%E8%AE%A2%E9%98%85%E9%80%9A%E7%9F%A5)并无写明该msgid返回参数，实测是返回该参数的，并且与回调的msgId一致。
因此给方法添加返回参数，用于下发结果回调时对应回具体的下发id。