### PR TITLE
fix bug  is_snapshotuser 	是否为快照页模式虚拟账号调整

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxOAuth2UserInfo.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/WxOAuth2UserInfo.java
@@ -58,11 +58,7 @@ public class WxOAuth2UserInfo implements Serializable {
    */
   @SerializedName("privilege")
   private String[] privileges;
-  /**
-   * is_snapshotuser  是否为快照页模式虚拟账号，值为0时是普通用户，1时是虚拟帐号
-   */
-  @SerializedName("is_snapshotuser")
-  private Integer snapshotUser;
+
 
   public static WxOAuth2UserInfo fromJson(String json) {
     return WxGsonBuilder.create().fromJson(json, WxOAuth2UserInfo.class);

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/oauth2/WxOAuth2AccessToken.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/bean/oauth2/WxOAuth2AccessToken.java
@@ -29,7 +29,9 @@ public class WxOAuth2AccessToken implements Serializable {
 
   @SerializedName("scope")
   private String scope;
-
+  /**
+   * 是否为快照页模式虚拟账号，只有当用户是快照页模式虚拟账号时返回，值为1
+   */
   @SerializedName("is_snapshotuser")
   private Integer snapshotUser;
 


### PR DESCRIPTION
是否为快照页模式虚拟账号，只在getAccessToken接口返回，不会在用户信息接口返回做此调整。