### PR TITLE
weixin-java-cp将int类型调整为Integer类型，将double类型调整为Double类型

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpUserExternalUserBehaviorStatistic.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpUserExternalUserBehaviorStatistic.java
@@ -39,43 +39,43 @@ public class WxCpUserExternalUserBehaviorStatistic extends WxCpBaseResp {
      * 聊天总数， 成员有主动发送过消息的聊天数，包括单聊和群聊。
      */
     @SerializedName("chat_cnt")
-    private int chatCnt;
+    private Integer chatCnt;
 
     /**
      * 发送消息数，成员在单聊和群聊中发送的消息总数。
      */
     @SerializedName("message_cnt")
-    private int messageCnt;
+    private Integer messageCnt;
 
     /**
      * 已回复聊天占比，客户主动发起聊天后，成员在一个自然日内有回复过消息的聊天数/客户主动发起的聊天数比例，不包括群聊，仅在确有回复时返回。
      */
     @SerializedName("reply_percentage")
-    private double replyPercentage;
+    private Double replyPercentage;
 
     /**
      * 平均首次回复时长，单位为分钟，即客户主动发起聊天后，成员在一个自然日内首次回复的时长间隔为首次回复时长，所有聊天的首次回复总时长/已回复的聊天总数即为平均首次回复时长，不包括群聊，仅在确有回复时返回。
      */
     @SerializedName("avg_reply_time")
-    private int avgReplyTime;
+    private Integer avgReplyTime;
 
     /**
      * 删除/拉黑成员的客户数，即将成员删除或加入黑名单的客户数。
      */
     @SerializedName("negative_feedback_cnt")
-    private int negativeFeedbackCnt;
+    private Integer negativeFeedbackCnt;
 
     /**
      * 发起申请数，成员通过「搜索手机号」、「扫一扫」、「从微信好友中添加」、「从群聊中添加」、「添加共享、分配给我的客户」、「添加单向、双向删除好友关系的好友」、「从新的联系人推荐中添加」等渠道主动向客户发起的好友申请数量。
      */
     @SerializedName("new_apply_cnt")
-    private int newApplyCnt;
+    private Integer newApplyCnt;
 
     /**
      * 新增客户数，成员新添加的客户数量。
      */
     @SerializedName("new_contact_cnt")
-    private int newContactCnt;
+    private Integer newContactCnt;
   }
 
   /**


### PR DESCRIPTION
“获取「联系客户统计」数据”这个接口中，behavior_data.reply_percentage、behavior_data.avg_reply_time这两个字段，仅在确有聊天时返回。如果使用int、double基本类型去进行参数接收。企业微信返回0和返回空，都会被转换为0，导致数据不准确。