### PR TITLE
:bug: 【开放平台】 fix H5 版授权链接错误的问题

### DIFF
--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
@@ -75,7 +75,7 @@ public interface WxOpenComponentService {
   /**
    * 手机端打开授权链接.
    */
-  String COMPONENT_MOBILE_LOGIN_PAGE_URL = "https://mp.weixin.qq.com/safe/bindcomponent?action=bindcomponent&no_scan=1&auth_type=3&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&auth_type=xxx&biz_appid=xxx#wechat_redirect";
+  String COMPONENT_MOBILE_LOGIN_PAGE_URL = "https://open.weixin.qq.com/wxaopen/safe/bindcomponent?action=bindcomponent&no_scan=1&component_appid=%s&pre_auth_code=%s&redirect_uri=%s&auth_type=xxx&biz_appid=xxx#wechat_redirect";
   /**
    * The constant CONNECT_OAUTH2_AUTHORIZE_URL.
    */


### PR DESCRIPTION
修改代码中与【开放平台】文档描述不相符的H5授权链接（当下链接有两个问题：* 不是最新的 * auth_type值错误）。

相关文档：https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/Before_Develop/Authorization_Process_Technical_Description.html “授权链接拼接方式”部分