### PR TITLE
weixin-java-open 新增 小程序认证上传补充材料

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/WxMaUploadAuthMaterialResult.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/WxMaUploadAuthMaterialResult.java
@@ -1,0 +1,32 @@
+package cn.binarywang.wx.miniapp.bean;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import me.chanjar.weixin.common.util.json.WxGsonBuilder;
+
+import java.io.Serializable;
+
+/**
+ * 小程序认证上传补充材料
+ *
+ * @author penhuozhu
+ * @since 2024/01/07
+ */
+@Data
+public class WxMaUploadAuthMaterialResult implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String type;
+
+    @SerializedName("mediaid")
+    private String mediaId;
+
+    public static WxMaUploadAuthMaterialResult fromJson(String json) {
+        return WxGsonBuilder.create().fromJson(json, WxMaUploadAuthMaterialResult.class);
+    }
+
+    @Override
+    public String toString() {
+        return WxGsonBuilder.create().toJson(this);
+    }
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/ApacheUploadAuthMaterialRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/ApacheUploadAuthMaterialRequestExecutor.java
@@ -1,0 +1,57 @@
+package cn.binarywang.wx.miniapp.executor;
+
+import cn.binarywang.wx.miniapp.bean.WxMaUploadAuthMaterialResult;
+import me.chanjar.weixin.common.enums.WxType;
+import me.chanjar.weixin.common.error.WxError;
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.http.RequestHttp;
+import me.chanjar.weixin.common.util.http.apache.Utf8ResponseHandler;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author penhuozhu
+ * @since 2024/01/07
+ */
+public class ApacheUploadAuthMaterialRequestExecutor extends UploadAuthMaterialRequestExecutor<CloseableHttpClient, HttpHost> {
+
+    public ApacheUploadAuthMaterialRequestExecutor(RequestHttp requestHttp) {
+        super(requestHttp);
+    }
+
+    @Override
+    public WxMaUploadAuthMaterialResult execute(String uri, File file, WxType wxType) throws WxErrorException, IOException {
+        HttpPost httpPost = new HttpPost(uri);
+        if (requestHttp.getRequestHttpProxy() != null) {
+            RequestConfig config = RequestConfig.custom().setProxy(requestHttp.getRequestHttpProxy()).build();
+            httpPost.setConfig(config);
+        }
+        if (file != null) {
+            HttpEntity entity = MultipartEntityBuilder
+                    .create()
+                    .addBinaryBody("media", file)
+                    .setMode(HttpMultipartMode.RFC6532)
+                    .build();
+            httpPost.setEntity(entity);
+        }
+        try (CloseableHttpResponse response = requestHttp.getRequestHttpClient().execute(httpPost)) {
+            String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);
+            WxError error = WxError.fromJson(responseContent, wxType);
+            if (error.getErrorCode() != 0) {
+                throw new WxErrorException(error);
+            }
+            return WxMaUploadAuthMaterialResult.fromJson(responseContent);
+        } finally {
+            httpPost.releaseConnection();
+        }
+    }
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/JoddHttpUploadAuthMaterialRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/JoddHttpUploadAuthMaterialRequestExecutor.java
@@ -1,0 +1,45 @@
+package cn.binarywang.wx.miniapp.executor;
+
+import cn.binarywang.wx.miniapp.bean.WxMaUploadAuthMaterialResult;
+import jodd.http.HttpConnectionProvider;
+import jodd.http.HttpRequest;
+import jodd.http.HttpResponse;
+import jodd.http.ProxyInfo;
+import me.chanjar.weixin.common.enums.WxType;
+import me.chanjar.weixin.common.error.WxError;
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.http.RequestHttp;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author penhuozhu
+ * @since 2024/01/07
+ */
+public class JoddHttpUploadAuthMaterialRequestExecutor extends UploadAuthMaterialRequestExecutor<HttpConnectionProvider, ProxyInfo> {
+
+    public JoddHttpUploadAuthMaterialRequestExecutor(RequestHttp requestHttp) {
+        super(requestHttp);
+    }
+
+    @Override
+    public WxMaUploadAuthMaterialResult execute(String uri, File file, WxType wxType) throws WxErrorException, IOException {
+        HttpRequest request = HttpRequest.post(uri);
+        if (requestHttp.getRequestHttpProxy() != null) {
+            requestHttp.getRequestHttpClient().useProxy(requestHttp.getRequestHttpProxy());
+        }
+        request.withConnectionProvider(requestHttp.getRequestHttpClient());
+        request.form("media", file);
+        HttpResponse response = request.send();
+        response.charset(StandardCharsets.UTF_8.name());
+
+        String responseContent = response.bodyText();
+        WxError error = WxError.fromJson(responseContent, wxType);
+        if (error.getErrorCode() != 0) {
+            throw new WxErrorException(error);
+        }
+        return WxMaUploadAuthMaterialResult.fromJson(responseContent);
+    }
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/OkHttpUploadAuthMaterialRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/OkHttpUploadAuthMaterialRequestExecutor.java
@@ -1,0 +1,43 @@
+package cn.binarywang.wx.miniapp.executor;
+
+import cn.binarywang.wx.miniapp.bean.WxMaUploadAuthMaterialResult;
+import me.chanjar.weixin.common.enums.WxType;
+import me.chanjar.weixin.common.error.WxError;
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.http.RequestHttp;
+import me.chanjar.weixin.common.util.http.okhttp.OkHttpProxyInfo;
+import okhttp3.*;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author penhuozhu
+ * @since 2024/01/07
+ */
+public class OkHttpUploadAuthMaterialRequestExecutor extends UploadAuthMaterialRequestExecutor<OkHttpClient, OkHttpProxyInfo> {
+
+    public OkHttpUploadAuthMaterialRequestExecutor(RequestHttp requestHttp) {
+        super(requestHttp);
+    }
+
+    @Override
+    public WxMaUploadAuthMaterialResult execute(String uri, File file, WxType wxType) throws WxErrorException, IOException {
+
+        RequestBody body = new MultipartBody.Builder()
+                .setType(MediaType.parse("multipart/form-data"))
+                .addFormDataPart("media",
+                        file.getName(),
+                        RequestBody.create(MediaType.parse("application/octet-stream"), file))
+                .build();
+        Request request = new Request.Builder().url(uri).post(body).build();
+
+        Response response = requestHttp.getRequestHttpClient().newCall(request).execute();
+        String responseContent = response.body().string();
+        WxError error = WxError.fromJson(responseContent, wxType);
+        if (error.getErrorCode() != 0) {
+            throw new WxErrorException(error);
+        }
+        return WxMaUploadAuthMaterialResult.fromJson(responseContent);
+    }
+}

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/UploadAuthMaterialRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/executor/UploadAuthMaterialRequestExecutor.java
@@ -1,0 +1,45 @@
+package cn.binarywang.wx.miniapp.executor;
+
+import cn.binarywang.wx.miniapp.bean.WxMaUploadAuthMaterialResult;
+import me.chanjar.weixin.common.enums.WxType;
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.http.RequestExecutor;
+import me.chanjar.weixin.common.util.http.RequestHttp;
+import me.chanjar.weixin.common.util.http.ResponseHandler;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * 小程序认证上传补充材料
+ * 上传媒体文件请求执行器.
+ * 请求的参数是File, 返回的结果是String
+ *
+ * @author penhuozhu
+ * @since 2024/01/07
+ */
+public abstract class UploadAuthMaterialRequestExecutor<H, P> implements RequestExecutor<WxMaUploadAuthMaterialResult, File> {
+    protected RequestHttp<H, P> requestHttp;
+
+    public UploadAuthMaterialRequestExecutor(RequestHttp requestHttp) {
+        this.requestHttp = requestHttp;
+    }
+
+    @Override
+    public void execute(String uri, File data, ResponseHandler<WxMaUploadAuthMaterialResult> handler, WxType wxType) throws WxErrorException, IOException {
+        handler.handle(this.execute(uri, data, wxType));
+    }
+
+    public static RequestExecutor<WxMaUploadAuthMaterialResult, File> create(RequestHttp requestHttp) {
+        switch (requestHttp.getRequestType()) {
+            case APACHE_HTTP:
+                return new ApacheUploadAuthMaterialRequestExecutor(requestHttp);
+            case JODD_HTTP:
+                return new JoddHttpUploadAuthMaterialRequestExecutor(requestHttp);
+            case OK_HTTP:
+                return new OkHttpUploadAuthMaterialRequestExecutor(requestHttp);
+            default:
+                return null;
+        }
+    }
+}

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenMaService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenMaService.java
@@ -2,6 +2,7 @@ package me.chanjar.weixin.open.api;
 
 import cn.binarywang.wx.miniapp.api.WxMaService;
 import cn.binarywang.wx.miniapp.bean.WxMaAuditMediaUploadResult;
+import cn.binarywang.wx.miniapp.bean.WxMaUploadAuthMaterialResult;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.open.bean.ma.WxMaPrefetchDomain;
 import me.chanjar.weixin.open.bean.ma.WxMaScheme;
@@ -272,6 +273,11 @@ public interface WxOpenMaService extends WxMaService {
    * 申请开通直播
    */
   String API_WX_APPLY_LIVE_INFO = "https://api.weixin.qq.com/wxa/business/applyliveinfo";
+
+  /**
+   * 小程序认证上传补充材料
+   */
+  String API_UPLOAD_AUTH_MATERIAL = "https://api.weixin.qq.com/wxa/sec/uploadauthmaterial";
 
   /**
    * 获得小程序的域名配置信息
@@ -751,5 +757,12 @@ public interface WxOpenMaService extends WxMaService {
    * @throws WxErrorException the wx error exception
    */
   WxOpenMaApplyLiveInfoResult applyLiveInfo() throws WxErrorException;
+
+  /**
+   * 小程序认证上传补充材料
+   *
+   * @return
+   */
+  WxMaUploadAuthMaterialResult uploadAuthMaterial(File file) throws WxErrorException;
 
 }

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenMaServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenMaServiceImpl.java
@@ -4,8 +4,10 @@ import cn.binarywang.wx.miniapp.api.WxMaService;
 import cn.binarywang.wx.miniapp.api.impl.WxMaServiceImpl;
 import cn.binarywang.wx.miniapp.bean.WxMaAuditMediaUploadResult;
 import cn.binarywang.wx.miniapp.bean.WxMaJscode2SessionResult;
+import cn.binarywang.wx.miniapp.bean.WxMaUploadAuthMaterialResult;
 import cn.binarywang.wx.miniapp.config.WxMaConfig;
 import cn.binarywang.wx.miniapp.executor.AuditMediaUploadRequestExecutor;
+import cn.binarywang.wx.miniapp.executor.UploadAuthMaterialRequestExecutor;
 import cn.binarywang.wx.miniapp.json.WxMaGsonBuilder;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -465,5 +467,10 @@ public class WxOpenMaServiceImpl extends WxMaServiceImpl implements WxOpenMaServ
     params.addProperty(ACTION, "apply");
     String response = post(API_WX_APPLY_LIVE_INFO, GSON.toJson(params));
     return WxMaGsonBuilder.create().fromJson(response, WxOpenMaApplyLiveInfoResult.class);
+  }
+
+  @Override
+  public WxMaUploadAuthMaterialResult uploadAuthMaterial(File file) throws WxErrorException {
+    return (WxMaUploadAuthMaterialResult) this.execute(UploadAuthMaterialRequestExecutor.create(getRequestHttp()), API_UPLOAD_AUTH_MATERIAL, file);
   }
 }


### PR DESCRIPTION
2023_12_25开放平台（第三方平台api），通过“快速注册企业小程序”创建的小程序必须认证，并新增了小程序微信认证相关的多个接口