### PR TITLE
推荐更新 lombok 到 1.18.30 解决 java 21 下编译时 lombok 导致报错的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.24</version>
+        <version>1.18.30</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
目前可以确认 lombok 最新版本 1.18.30 已解决 java 21 下编译时会出现以下报错的问题：
```
Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid'
```
![image](https://github.com/Wechat-Group/WxJava/assets/57629614/35d2b355-af45-4319-8129-2de345784c40)
