### PR TITLE
:new: #3188 【视频号】实现视频号助手相关接口

### DIFF
--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxAssistantService.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxAssistantService.java
@@ -1,0 +1,55 @@
+package me.chanjar.weixin.channel.api;
+
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+import me.chanjar.weixin.channel.bean.window.request.AddWindowProductRequest;
+import me.chanjar.weixin.channel.bean.window.request.GetWindowProductListRequest;
+import me.chanjar.weixin.channel.bean.window.request.WindowProductRequest;
+import me.chanjar.weixin.channel.bean.window.response.GetWindowProductListResponse;
+import me.chanjar.weixin.channel.bean.window.response.GetWindowProductResponse;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+/**
+ * 视频号助手 橱窗管理服务 <br/>
+ * 关于橱窗商品ID的说明: <br/>
+ * 不支持带货中心来源的商品，其余商品的橱窗商品ID与商品来源处的平台内部商品ID相同，对应关系如下 <br/>
+ * <pre>
+ * 商品来源	橱窗ID说明
+ * 视频号小店	视频号小店商品的 product_id 字段
+ * 交易组件	组件商品的 product_id 字段
+ * </pre>
+ *
+ * @author <a href="https://github.com/imyzt">imyzt</a>
+ */
+public interface WxAssistantService {
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/windowproduct/add.html">上架商品到橱窗</a>
+   * @param req 商品信息
+   * @return 操作结果
+   */
+  WxChannelBaseResponse addWindowProduct(AddWindowProductRequest req) throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/windowproduct/get.html">获取橱窗商品详情</a>
+   *
+   * @param req 商品信息
+   * @return 橱窗商品详情
+   */
+  GetWindowProductResponse getWindowProduct(WindowProductRequest req) throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/windowproduct/list_get.html">获取已添加到橱窗的商品列表</a>
+   * 接口限制了 page_size × page_index ≤ 10000。命中限制时建议改用传last_buffer顺序翻页的请求方式
+   * @param req 商品信息
+   * @return 已添加到橱窗的商品列表
+   */
+  GetWindowProductListResponse getWindowProductList(GetWindowProductListRequest req) throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/windowproduct/off.html">下架橱窗商品</a>
+   * @param req 商品信息
+   * @return 操作结果
+   */
+  WxChannelBaseResponse offWindowProduct(WindowProductRequest req) throws WxErrorException;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxChannelService.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxChannelService.java
@@ -119,4 +119,25 @@ public interface WxChannelService extends BaseWxChannelService {
    */
   WxLeagueProductService getLeagueProductService();
 
+  /**
+   * 视频号助手 留资组件管理服务
+   *
+   * @return 留资组件管理服务
+   */
+  WxLeadComponentService getLeadComponentService();
+
+  /**
+   * 视频号助手 留资服务的直播数据服务
+   *
+   * @return 留资服务的直播数据服务
+   */
+  WxFinderLiveService getFinderLiveService();
+
+  /**
+   * 视频号助手 橱窗管理服务
+   *
+   * @return 橱窗管理服务
+   */
+  WxAssistantService getAssistantService();
+
 }

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxFinderLiveService.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxFinderLiveService.java
@@ -1,0 +1,41 @@
+package me.chanjar.weixin.channel.api;
+
+import me.chanjar.weixin.channel.bean.lead.component.request.GetFinderLiveDataListRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetFinderLiveLeadsDataRequest;
+import me.chanjar.weixin.channel.bean.lead.component.response.FinderAttrResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetFinderLiveDataListResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetFinderLiveLeadsDataResponse;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+/**
+ * 视频号助手 留资服务的直播数据服务
+ *
+ * @author <a href="https://github.com/imyzt">imyzt</a>
+ */
+public interface WxFinderLiveService {
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/live/get_finder_attr_by_appid.html">获取视频号账号信息</a>
+   *
+   * @return 视频号账号信息
+   */
+  FinderAttrResponse getFinderAttrByAppid() throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/live/get_finder_live_data_list.html">获取留资直播间数据详情</a>
+   *
+   * @param req 留资组件信息
+   * @return 留资信息详情
+   */
+  GetFinderLiveDataListResponse getFinderLiveDataList(GetFinderLiveDataListRequest req) throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/live/get_finder_live_leads_data.html">获取账号收集的留资数量</a>
+   * 说明：该接口只统计2023.9.13号起的数据，所以start_time应大于等于1694534400
+   *
+   * @param req 留资组件信息
+   * @return 留资信息列表
+   */
+  GetFinderLiveLeadsDataResponse getFinderLiveLeadsData(GetFinderLiveLeadsDataRequest req) throws WxErrorException;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxLeadComponentService.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxLeadComponentService.java
@@ -1,0 +1,60 @@
+package me.chanjar.weixin.channel.api;
+
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadInfoByComponentRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsComponentIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsComponentPromoteRecordRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsInfoByRequestIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsRequestIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsComponentIdResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsComponentPromoteRecordResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsRequestIdResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.LeadInfoResponse;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+/**
+ * 视频号助手 留资组件管理服务
+ *
+ * @author <a href="https://github.com/imyzt">imyzt</a>
+ */
+public interface WxLeadComponentService {
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_info_by_component_id.html">按时间获取留资信息详情</a>
+   *
+   * @param req 留资组件信息
+   * @return 留资信息详情
+   */
+  LeadInfoResponse getLeadsInfoByComponentId(GetLeadInfoByComponentRequest req) throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_info_by_request_id.html">按直播场次获取留资信息详情</a>
+   *
+   * @param req 留资组件信息
+   * @return 留资信息详情
+   */
+  LeadInfoResponse getLeadsInfoByRequestId(GetLeadsInfoByRequestIdRequest req) throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_request_id.html">获取留资request_id列表详情</a>
+   *
+   * @param req 留资组件信息
+   * @return 留资信息列表
+   */
+  GetLeadsRequestIdResponse getLeadsRequestId(GetLeadsRequestIdRequest req) throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_component_promote_record.html">获取留资组件直播推广记录信息详情</a>
+   *
+   * @param req 留资组件信息
+   * @return 留资组件直播推广记录信息详情
+   */
+  GetLeadsComponentPromoteRecordResponse getLeadsComponentPromoteRecord(GetLeadsComponentPromoteRecordRequest req) throws WxErrorException;
+
+  /**
+   * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_component_id.html">获取留资组件Id列表详情</a>
+   *
+   * @param req 留资组件信息
+   * @return 留资组件Id列表
+   */
+  GetLeadsComponentIdResponse getLeadsComponentId(GetLeadsComponentIdRequest req) throws WxErrorException;
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/BaseWxChannelServiceImpl.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/BaseWxChannelServiceImpl.java
@@ -3,7 +3,26 @@ package me.chanjar.weixin.channel.api.impl;
 
 import com.google.gson.JsonObject;
 import lombok.extern.slf4j.Slf4j;
-import me.chanjar.weixin.channel.api.*;
+import me.chanjar.weixin.channel.api.WxAssistantService;
+import me.chanjar.weixin.channel.api.WxChannelAddressService;
+import me.chanjar.weixin.channel.api.WxChannelAfterSaleService;
+import me.chanjar.weixin.channel.api.WxChannelBasicService;
+import me.chanjar.weixin.channel.api.WxChannelBrandService;
+import me.chanjar.weixin.channel.api.WxChannelCategoryService;
+import me.chanjar.weixin.channel.api.WxChannelCouponService;
+import me.chanjar.weixin.channel.api.WxChannelFreightTemplateService;
+import me.chanjar.weixin.channel.api.WxChannelFundService;
+import me.chanjar.weixin.channel.api.WxChannelOrderService;
+import me.chanjar.weixin.channel.api.WxChannelProductService;
+import me.chanjar.weixin.channel.api.WxChannelService;
+import me.chanjar.weixin.channel.api.WxChannelSharerService;
+import me.chanjar.weixin.channel.api.WxChannelWarehouseService;
+import me.chanjar.weixin.channel.api.WxFinderLiveService;
+import me.chanjar.weixin.channel.api.WxLeadComponentService;
+import me.chanjar.weixin.channel.api.WxLeagueProductService;
+import me.chanjar.weixin.channel.api.WxLeaguePromoterService;
+import me.chanjar.weixin.channel.api.WxLeagueSupplierService;
+import me.chanjar.weixin.channel.api.WxLeagueWindowService;
 import me.chanjar.weixin.channel.config.WxChannelConfig;
 import me.chanjar.weixin.channel.util.JsonUtils;
 import me.chanjar.weixin.common.api.WxConsts;
@@ -51,6 +70,9 @@ public abstract class BaseWxChannelServiceImpl<H, P> implements WxChannelService
   private WxLeagueSupplierService leagueSupplierService = null;
   private WxLeaguePromoterService leaguePromoterService = null;
   private WxLeagueProductService leagueProductService = null;
+  private WxLeadComponentService leadComponentService = null;
+  private WxFinderLiveService finderLiveService = null;
+  private WxAssistantService assistantService = null;
 
   protected WxChannelConfig config;
   private int retrySleepMillis = 1000;
@@ -377,4 +399,30 @@ public abstract class BaseWxChannelServiceImpl<H, P> implements WxChannelService
     }
     return leagueProductService;
   }
+
+  @Override
+  public WxLeadComponentService getLeadComponentService() {
+    if (leadComponentService == null) {
+      leadComponentService = new WxLeadComponentServiceImpl(this);
+    }
+    return leadComponentService;
+  }
+
+  @Override
+  public WxFinderLiveService getFinderLiveService() {
+    if (finderLiveService == null) {
+      finderLiveService = new WxFinderLiveServiceImpl(this);
+    }
+    return finderLiveService;
+  }
+
+  @Override
+  public WxAssistantService getAssistantService() {
+    if (assistantService == null) {
+      assistantService = new WxAssistantServiceImpl(this) {
+      };
+    }
+    return assistantService;
+  }
+
 }

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxAssistantServiceImpl.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxAssistantServiceImpl.java
@@ -1,0 +1,55 @@
+package me.chanjar.weixin.channel.api.impl;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.channel.api.WxAssistantService;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+import me.chanjar.weixin.channel.bean.window.request.AddWindowProductRequest;
+import me.chanjar.weixin.channel.bean.window.request.GetWindowProductListRequest;
+import me.chanjar.weixin.channel.bean.window.request.WindowProductRequest;
+import me.chanjar.weixin.channel.bean.window.response.GetWindowProductListResponse;
+import me.chanjar.weixin.channel.bean.window.response.GetWindowProductResponse;
+import me.chanjar.weixin.channel.util.ResponseUtils;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.Assistant.ADD_WINDOW_PRODUCT_URL;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.Assistant.GET_WINDOW_PRODUCT_URL;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.Assistant.LIST_WINDOW_PRODUCT_URL;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.Assistant.OFF_WINDOW_PRODUCT_URL;
+
+/**
+ * 视频号助手 橱窗管理服务
+ *
+ * @author <a href="https://github.com/imyzt">imyzt</a>
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class WxAssistantServiceImpl implements WxAssistantService {
+
+  /** 微信商店服务 */
+  private final BaseWxChannelServiceImpl shopService;
+  @Override
+  public WxChannelBaseResponse addWindowProduct(AddWindowProductRequest req) throws WxErrorException {
+    String resJson = shopService.post(ADD_WINDOW_PRODUCT_URL, "{}");
+    return ResponseUtils.decode(resJson, WxChannelBaseResponse.class);
+  }
+
+  @Override
+  public GetWindowProductResponse getWindowProduct(WindowProductRequest req) throws WxErrorException {
+    String resJson = shopService.post(GET_WINDOW_PRODUCT_URL, "{}");
+    return ResponseUtils.decode(resJson, GetWindowProductResponse.class);
+  }
+
+  @Override
+  public GetWindowProductListResponse getWindowProductList(GetWindowProductListRequest req) throws WxErrorException {
+    String resJson = shopService.post(LIST_WINDOW_PRODUCT_URL, "{}");
+    return ResponseUtils.decode(resJson, GetWindowProductListResponse.class);
+  }
+
+  @Override
+  public WxChannelBaseResponse offWindowProduct(WindowProductRequest req) throws WxErrorException {
+    String resJson = shopService.post(OFF_WINDOW_PRODUCT_URL, "{}");
+    return ResponseUtils.decode(resJson, WxChannelBaseResponse.class);
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxFinderLiveServiceImpl.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxFinderLiveServiceImpl.java
@@ -1,0 +1,47 @@
+package me.chanjar.weixin.channel.api.impl;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.channel.api.WxFinderLiveService;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetFinderLiveDataListRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetFinderLiveLeadsDataRequest;
+import me.chanjar.weixin.channel.bean.lead.component.response.FinderAttrResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetFinderLiveDataListResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetFinderLiveLeadsDataResponse;
+import me.chanjar.weixin.channel.util.ResponseUtils;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.FinderLive.GET_FINDER_ATTR_BY_APPID;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.FinderLive.GET_FINDER_LIVE_DATA_LIST;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.FinderLive.GET_FINDER_LIVE_LEADS_DATA;
+
+/**
+ * 视频号助手 留资服务的直播数据服务
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class WxFinderLiveServiceImpl implements WxFinderLiveService {
+
+  /** 微信商店服务 */
+  private final BaseWxChannelServiceImpl shopService;
+  @Override
+  public FinderAttrResponse getFinderAttrByAppid() throws WxErrorException {
+    String resJson = shopService.post(GET_FINDER_ATTR_BY_APPID, "{}");
+    return ResponseUtils.decode(resJson, FinderAttrResponse.class);
+  }
+
+  @Override
+  public GetFinderLiveDataListResponse getFinderLiveDataList(GetFinderLiveDataListRequest req) throws WxErrorException {
+    String resJson = shopService.post(GET_FINDER_LIVE_DATA_LIST, req);
+    return ResponseUtils.decode(resJson, GetFinderLiveDataListResponse.class);
+  }
+
+  @Override
+  public GetFinderLiveLeadsDataResponse getFinderLiveLeadsData(GetFinderLiveLeadsDataRequest req) throws WxErrorException {
+    String resJson = shopService.post(GET_FINDER_LIVE_LEADS_DATA, req);
+    return ResponseUtils.decode(resJson, GetFinderLiveLeadsDataResponse.class);
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxLeadComponentServiceImpl.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxLeadComponentServiceImpl.java
@@ -1,0 +1,65 @@
+package me.chanjar.weixin.channel.api.impl;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.channel.api.WxLeadComponentService;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadInfoByComponentRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsComponentIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsComponentPromoteRecordRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsInfoByRequestIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsRequestIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsComponentIdResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsComponentPromoteRecordResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsRequestIdResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.LeadInfoResponse;
+import me.chanjar.weixin.channel.util.ResponseUtils;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.LeadComponent.GET_LEADS_COMPONENT_ID;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.LeadComponent.GET_LEADS_COMPONENT_PROMOTE_RECORD;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.LeadComponent.GET_LEADS_INFO_BY_COMPONENT_ID;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.LeadComponent.GET_LEADS_INFO_BY_REQUEST_ID;
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.LeadComponent.GET_LEADS_REQUEST_ID;
+
+/**
+ * 视频号助手 留资组件管理服务
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class WxLeadComponentServiceImpl implements WxLeadComponentService {
+
+  /** 微信商店服务 */
+  private final BaseWxChannelServiceImpl shopService;
+  @Override
+  public LeadInfoResponse getLeadsInfoByComponentId(GetLeadInfoByComponentRequest req) throws WxErrorException {
+    String resJson = shopService.post(GET_LEADS_INFO_BY_COMPONENT_ID, req);
+    return ResponseUtils.decode(resJson, LeadInfoResponse.class);
+  }
+
+  @Override
+  public LeadInfoResponse getLeadsInfoByRequestId(GetLeadsInfoByRequestIdRequest req) throws WxErrorException {
+    String resJson = shopService.post(GET_LEADS_INFO_BY_REQUEST_ID, req);
+    return ResponseUtils.decode(resJson, LeadInfoResponse.class);
+  }
+
+  @Override
+  public GetLeadsRequestIdResponse getLeadsRequestId(GetLeadsRequestIdRequest req) throws WxErrorException {
+    String resJson = shopService.post(GET_LEADS_REQUEST_ID, req);
+    return ResponseUtils.decode(resJson, GetLeadsRequestIdResponse.class);
+  }
+
+  @Override
+  public GetLeadsComponentPromoteRecordResponse getLeadsComponentPromoteRecord(GetLeadsComponentPromoteRecordRequest req) throws WxErrorException {
+    String resJson = shopService.post(GET_LEADS_COMPONENT_PROMOTE_RECORD, req);
+    return ResponseUtils.decode(resJson, GetLeadsComponentPromoteRecordResponse.class);
+  }
+
+  @Override
+  public GetLeadsComponentIdResponse getLeadsComponentId(GetLeadsComponentIdRequest req) throws WxErrorException {
+    String resJson = shopService.post(GET_LEADS_COMPONENT_ID, req);
+    return ResponseUtils.decode(resJson, GetLeadsComponentIdResponse.class);
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetFinderLiveDataListRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetFinderLiveDataListRequest.java
@@ -1,0 +1,39 @@
+package me.chanjar.weixin.channel.bean.lead.component.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 留资直播间数据详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetFinderLiveDataListRequest {
+
+  /**
+   * 开始时间
+   */
+  @JsonProperty("start_time")
+  private Long startTime;
+
+  /**
+   * 结束时间
+   */
+  @JsonProperty("end_time")
+  private Long endTime;
+
+  /**
+   * 顺序翻页，传入上次请求返回的last_buffer, 会从上次返回的结果往后翻一页
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetFinderLiveLeadsDataRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetFinderLiveLeadsDataRequest.java
@@ -1,0 +1,40 @@
+package me.chanjar.weixin.channel.bean.lead.component.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 获取账号收集的留资数据详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetFinderLiveLeadsDataRequest {
+
+  /**
+   * 开始时间
+   */
+  @JsonProperty("start_time")
+  private Long startTime;
+
+  /**
+   * 结束时间
+   */
+  @JsonProperty("end_time")
+  private Long endTime;
+
+  /**
+   * 来源类型
+   * source_type	来源类型 0	直播
+   */
+  @JsonProperty("source_type")
+  private Long sourceType;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadInfoByComponentRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadInfoByComponentRequest.java
@@ -1,0 +1,51 @@
+package me.chanjar.weixin.channel.bean.lead.component.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 按时间获取留资信息详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetLeadInfoByComponentRequest {
+
+  /**
+   * 用于查询某个留资组件某段时间内收集的留资信息
+   */
+  @JsonProperty("leads_component_id")
+  private String leadsComponentId;
+
+  /**
+   * 开始时间
+   */
+  @JsonProperty("start_time")
+  private Long startTime;
+
+  /**
+   * 结束时间
+   */
+  @JsonProperty("end_time")
+  private Long endTime;
+
+  /**
+   * 顺序翻页，传入上次请求返回的last_buffer, 会从上次返回的结果往后翻一页
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 接口版本号
+   */
+  @JsonProperty("version")
+  private int version;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsComponentIdRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsComponentIdRequest.java
@@ -1,0 +1,27 @@
+package me.chanjar.weixin.channel.bean.lead.component.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 获取留资组件Id列表详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetLeadsComponentIdRequest {
+
+  /**
+   * 顺序翻页，传入上次请求返回的last_buffer, 会从上次返回的结果往后翻一页
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsComponentPromoteRecordRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsComponentPromoteRecordRequest.java
@@ -1,0 +1,45 @@
+package me.chanjar.weixin.channel.bean.lead.component.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 获取留资组件直播推广记录信息详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetLeadsComponentPromoteRecordRequest {
+
+  /**
+   * 用于查询某个留资组件某段时间内收集的留资信息
+   */
+  @JsonProperty("leads_component_id")
+  private String leadsComponentId;
+
+  /**
+   * 开始时间
+   */
+  @JsonProperty("start_time")
+  private Long startTime;
+
+  /**
+   * 结束时间
+   */
+  @JsonProperty("end_time")
+  private Long endTime;
+
+  /**
+   * 顺序翻页，传入上次请求返回的last_buffer, 会从上次返回的结果往后翻一页
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsInfoByRequestIdRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsInfoByRequestIdRequest.java
@@ -1,0 +1,39 @@
+package me.chanjar.weixin.channel.bean.lead.component.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 按直播场次获取留资信息详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetLeadsInfoByRequestIdRequest {
+
+  /**
+   * 用于查询某个留资组件某场直播收集的留资信息
+   */
+  @JsonProperty("request_id")
+  private String requestId;
+
+  /**
+   * 顺序翻页，传入上次请求返回的last_buffer, 会从上次返回的结果往后翻一页
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 接口版本号
+   */
+  @JsonProperty("version")
+  private int version;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsRequestIdRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsRequestIdRequest.java
@@ -1,0 +1,33 @@
+package me.chanjar.weixin.channel.bean.lead.component.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 获取留资request_id列表详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetLeadsRequestIdRequest {
+
+  /**
+   * 用于查询某个留资组件某段时间内收集的留资信息
+   */
+  @JsonProperty("leads_component_id")
+  private String leadsComponentId;
+
+  /**
+   * 顺序翻页，传入上次请求返回的last_buffer, 会从上次返回的结果往后翻一页
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/FinderAttrResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/FinderAttrResponse.java
@@ -1,0 +1,51 @@
+package me.chanjar.weixin.channel.bean.lead.component.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+/**
+ * 视频号账号信息
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class FinderAttrResponse extends WxChannelBaseResponse {
+
+  /**
+   * 用户留资信息列表
+   */
+  @JsonProperty("finder_attr")
+  private FinderAttr finderAttr;
+
+  /**
+   * 用户留资信息
+   */
+  @Data
+  @NoArgsConstructor
+  public static class FinderAttr {
+
+    /**
+     * 视频号唯一标识
+     */
+    @JsonProperty("uniq_id")
+    private String uniqId;
+
+    /**
+     * 视频号昵称
+     */
+    @JsonProperty("nickname")
+    private String nickname;
+
+    /**
+     * 视频号的粉丝数
+     */
+    @JsonProperty("fans_count")
+    private int fansCount;
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetFinderLiveDataListResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetFinderLiveDataListResponse.java
@@ -1,0 +1,112 @@
+package me.chanjar.weixin.channel.bean.lead.component.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 留资直播间数据详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class GetFinderLiveDataListResponse extends WxChannelBaseResponse {
+
+  /**
+   * 直播统计信息列表
+   */
+  @JsonProperty("item")
+  private List<LiveStatisticsItem> items;
+
+  /**
+   * 本次翻页的上下文，用于顺序翻页请求
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 是否还有直播
+   */
+  @JsonProperty("continue_flag")
+  private boolean continueFlag;
+
+  /**
+   * 直播统计信息
+   */
+  @Data
+  @NoArgsConstructor
+  public static class LiveStatisticsItem {
+    /**
+     * 直播唯一id
+     */
+    @JsonProperty("export_id")
+    private String exportId;
+
+    /**
+     * 开播时间戳
+     */
+    @JsonProperty("live_start_time")
+    private Long liveStartTime;
+
+    /**
+     * 直播时长
+     */
+    @JsonProperty("live_duration_in_seconds")
+    private Long liveDurationInSeconds;
+
+    /**
+     * 观看人数
+     */
+    @JsonProperty("total_audience_count")
+    private Long totalAudienceCount;
+
+    /**
+     * 喝彩次数
+     */
+    @JsonProperty("total_cheer_count")
+    private Long totalCheerCount;
+
+    /**
+     * 分享次数
+     */
+    @JsonProperty("forward_count")
+    private Long forwardCount;
+
+    /**
+     * 评论条数
+     */
+    @JsonProperty("total_comment_count")
+    private Long totalCommentCount;
+
+    /**
+     * 人均观看时长
+     */
+    @JsonProperty("audiences_avg_seconds")
+    private Long audiencesAvgSeconds;
+
+    /**
+     * 最高在线人数
+     */
+    @JsonProperty("max_online_count")
+    private Long maxOnlineCount;
+
+    /**
+     * 新增粉丝
+     */
+    @JsonProperty("new_follow_count")
+    private Long newFollowCount;
+
+    /**
+     * 公众号新增粉丝
+     */
+    @JsonProperty("new_follow_count_biz")
+    private Long newFollowCountBiz;
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetFinderLiveLeadsDataResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetFinderLiveLeadsDataResponse.java
@@ -1,0 +1,59 @@
+package me.chanjar.weixin.channel.bean.lead.component.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 获取账号收集的留资数据详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class GetFinderLiveLeadsDataResponse extends WxChannelBaseResponse {
+
+  /**
+   * 留资统计信息列表
+   */
+  @JsonProperty("item")
+  private List<LeadCountItem> items;
+
+  /**
+   * 留资统计信息
+   */
+  @Data
+  @NoArgsConstructor
+  public static class LeadCountItem {
+
+    /**
+     * 组件类型
+     * 0	表单
+     * 1	企微名片
+     * 2	企微客服
+     */
+    @JsonProperty("component_type")
+    private int componentType;
+
+    /**
+     * 流量来源
+     * 0	自然流量
+     * 1	广告流量
+     */
+    @JsonProperty("traffic_type")
+    private int trafficType;
+
+    /**
+     * 留资条数
+     */
+    @JsonProperty("leads_count")
+    private int leadsCount;
+
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetLeadsComponentIdResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetLeadsComponentIdResponse.java
@@ -1,0 +1,65 @@
+package me.chanjar.weixin.channel.bean.lead.component.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 留资组件Id列表详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class GetLeadsComponentIdResponse extends WxChannelBaseResponse {
+
+  /**
+   * 留资组件信息
+   */
+  @JsonProperty("item")
+  private List<LeadComponentItem> item;
+
+  /**
+   * 本次翻页的上下文，用于顺序翻页请求
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 是否还有留资信息
+   */
+  @JsonProperty("continue_flag")
+  private boolean continueFlag;
+
+  /**
+   * 留资组件信息
+   */
+  @Data
+  @NoArgsConstructor
+  public static class LeadComponentItem {
+
+    /**
+     * 留资组件id
+     */
+    @JsonProperty("leads_component_id")
+    private String leadsComponentId;
+
+    /**
+     * 留资组件标题
+     */
+    @JsonProperty("leads_description")
+    private String leadsDescription;
+
+    /**
+     * 留资组件状态码
+     */
+    @JsonProperty("status")
+    private int status;
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetLeadsComponentPromoteRecordResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetLeadsComponentPromoteRecordResponse.java
@@ -1,0 +1,71 @@
+package me.chanjar.weixin.channel.bean.lead.component.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 获取留资组件直播推广记录信息详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class GetLeadsComponentPromoteRecordResponse extends WxChannelBaseResponse {
+
+  /**
+   * 留资组件直播推广记录列表
+   */
+  @JsonProperty("record_data")
+  private List<RecordData> recordData;
+
+  /**
+   * 本次翻页的上下文，用于顺序翻页请求
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 是否还有留资信息
+   */
+  @JsonProperty("continue_flag")
+  private boolean continueFlag;
+
+  /**
+   * 留资组件直播推广记录列表
+   */
+  @Data
+  @NoArgsConstructor
+  public static class RecordData {
+
+    @JsonProperty("anchor_nickname")
+    private String anchorNickname;
+
+    @JsonProperty("live_description")
+    private String liveDescription;
+
+    @JsonProperty("live_start_time")
+    private long liveStartTime;
+
+    @JsonProperty("live_audience_count")
+    private String liveAudienceCount;
+
+    @JsonProperty("exposure_uv")
+    private String exposureUV;
+
+    @JsonProperty("click_uv")
+    private String clickUV;
+
+    @JsonProperty("exposure_click_rate")
+    private double exposureClickRate;
+
+    @JsonProperty("leads_num")
+    private String leadsNum;
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetLeadsRequestIdResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/GetLeadsRequestIdResponse.java
@@ -1,0 +1,66 @@
+package me.chanjar.weixin.channel.bean.lead.component.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 获取留资request_id列表详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class GetLeadsRequestIdResponse extends WxChannelBaseResponse {
+
+  /**
+   * 某一场直播对应的留资信息请求id
+   */
+  @JsonProperty("item")
+  private List<LiveLeadItem> items;
+
+  /**
+   * 本次翻页的上下文，用于顺序翻页请求
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 是否还有留资信息
+   */
+  @JsonProperty("continue_flag")
+  private boolean continueFlag;
+
+  /**
+   * 直播对应的留资信息
+   */
+  @Data
+  @NoArgsConstructor
+  public static class LiveLeadItem {
+
+    /**
+     * 某一场直播对应的留资信息请求id
+     */
+    @JsonProperty("request_id")
+    private String requestId;
+
+    /**
+     * 直播开始时间
+     */
+    @JsonProperty("live_start_time")
+    private Long liveStartTime;
+
+    /**
+     * 直播描述
+     */
+    @JsonProperty("live_description")
+    private String liveDescription;
+
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/LeadInfoResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/LeadInfoResponse.java
@@ -1,0 +1,53 @@
+package me.chanjar.weixin.channel.bean.lead.component.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 留资信息详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class LeadInfoResponse extends WxChannelBaseResponse {
+
+  /**
+   * 用户留资信息列表
+   */
+  @JsonProperty("user_data")
+  private List<UserData> userData;
+
+  /**
+   * 本次翻页的上下文，用于顺序翻页请求
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 是否还有留资信息
+   */
+  @JsonProperty("continue_flag")
+  private boolean continueFlag;
+
+  /**
+   * 用户留资信息
+   */
+  @Data
+  @NoArgsConstructor
+  public static class UserData {
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("value")
+    private String value;
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/request/AddWindowProductRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/request/AddWindowProductRequest.java
@@ -1,0 +1,39 @@
+package me.chanjar.weixin.channel.bean.window.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 上架商品到橱窗
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddWindowProductRequest {
+
+  /**
+   * 橱窗商品ID
+   */
+  @JsonProperty("product_id")
+  private String productId;
+
+  /**
+   * 商品来源店铺的appid
+   */
+  @JsonProperty("appid")
+  private String appid;
+
+  /**
+   * 是否需要在个人橱窗页隐藏 (默认为false)
+   */
+  @JsonProperty("is_hide_for_window")
+  private Boolean isHideForWindow;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/request/GetWindowProductListRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/request/GetWindowProductListRequest.java
@@ -1,0 +1,57 @@
+package me.chanjar.weixin.channel.bean.window.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 获取账号收集的留资数据详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetWindowProductListRequest {
+
+  /**
+   * 用于指定查询某个店铺来源的商品
+   */
+  @JsonProperty("appid")
+  private String appid;
+
+  /**
+   * 用于指定查询属于某个分店ID下的商品
+   */
+  @JsonProperty("branch_id")
+  private int branchId;
+
+  /**
+   * 单页商品数（不超过200）
+   */
+  @JsonProperty("page_size")
+  private int pageSize;
+
+  /**
+   * 页面下标，下标从1开始，默认为1
+   */
+  @JsonProperty("page_index")
+  private int pageIndex;
+
+  /**
+   * 由上次请求返回，顺序翻页时需要传入，会从上次返回的结果往后翻一页（填了该值后page_index不生效）
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 是否需要返回满足筛选条件的商品总数
+   */
+  @JsonProperty("need_total_num")
+  private int needTotalNum;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/request/WindowProductRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/request/WindowProductRequest.java
@@ -1,0 +1,32 @@
+package me.chanjar.weixin.channel.bean.window.request;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 橱窗商品
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class WindowProductRequest {
+
+  /**
+   * 橱窗商品ID
+   */
+  @JsonProperty("product_id")
+  private String productId;
+
+  /**
+   * 商品来源店铺的appid
+   */
+  @JsonProperty("appid")
+  private String appid;
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/response/GetWindowProductListResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/response/GetWindowProductListResponse.java
@@ -1,0 +1,55 @@
+package me.chanjar.weixin.channel.bean.window.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 获取账号收集的留资数据详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class GetWindowProductListResponse extends WxChannelBaseResponse {
+
+  /**
+   * 商品列表
+   */
+  private List<ProductInfo> products;
+
+  /**
+   * 本次翻页的上下文，用于顺序翻页请求
+   */
+  @JsonProperty("last_buffer")
+  private String lastBuffer;
+
+  /**
+   * 商品总数
+   */
+  @JsonProperty("total_num")
+  private int totalNum;
+
+  /**
+   * 商品信息类
+   */
+  @Data
+  public static class ProductInfo {
+    /**
+     * 橱窗商品id
+     */
+    @JsonProperty("product_id")
+    private String productId;
+
+    /**
+     * 商品来源店铺的appid
+     */
+    private String appid;
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/response/GetWindowProductResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/window/response/GetWindowProductResponse.java
@@ -1,0 +1,238 @@
+package me.chanjar.weixin.channel.bean.window.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+/**
+ * 获取橱窗商品详情
+ * @author imyzt
+ * @date 2024/01/27
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class GetWindowProductResponse extends WxChannelBaseResponse {
+
+  /**
+   * 橱窗商品详情
+   */
+  @JsonProperty("product")
+  private String product;
+
+  @Data
+  public static class Product {
+    /**
+     * 橱窗商品ID
+     */
+    @JsonProperty("product_id")
+    private String productId;
+
+    /**
+     * 商家侧外部商品ID
+     */
+    @JsonProperty("out_product_id")
+    private String outProductId;
+
+    /**
+     * 商品标题
+     */
+    private String title;
+
+    /**
+     * 商品头图url
+     */
+    @JsonProperty("img_url")
+    private String imgUrl;
+
+    /**
+     * 商品所属三级类目ID
+     */
+    @JsonProperty("third_category_id")
+    private String thirdCategoryId;
+
+    /**
+     * 商品状态
+     * 1	已上架到橱窗
+     * 2	未上架到橱窗
+     * 3	已在商品来源处删除
+     */
+    private Integer status;
+
+    /**
+     * 价格区间最大值(单位分) (市场价，原价）
+     */
+    @JsonProperty("market_price")
+    private Long marketPrice;
+
+    /**
+     * 价格区间最小值(单位分) (销售价)
+     */
+    @JsonProperty("selling_price")
+    private Long sellingPrice;
+
+    /**
+     * 剩余库存
+     */
+    private Long stock;
+
+    /**
+     * 商品来源店铺的appid(非带货商品才拥有)
+     */
+    private String appid;
+
+    /**
+     * 商品详情页路径信息
+     */
+    @JsonProperty("page_path")
+    private PagePath pagePath;
+
+    /**
+     * 商品所属电商平台ID
+     */
+    @JsonProperty("platform_id")
+    private Long platformId;
+
+    /**
+     * 商品所属电商平台名
+     */
+    @JsonProperty("platform_name")
+    private String platformName;
+
+    /**
+     * 是否在个人橱窗页隐藏
+     */
+    @JsonProperty("is_hide_for_window")
+    private Boolean isHideForWindow;
+
+    /**
+     * 商品是否处于禁止售卖的状态
+     */
+    private Boolean banned;
+
+    /**
+     * 禁售原因及申请相关信息
+     */
+    @JsonProperty("banned_details")
+    private BannedDetails bannedDetails;
+
+    /**
+     * 分店信息
+     */
+    @JsonProperty("branch_info")
+    private BranchInfo branchInfo;
+
+    /**
+     * 抢购活动信息
+     */
+    @JsonProperty("limit_discount_info")
+    private LimitDiscountInfo limitDiscountInfo;
+  }
+
+  /**
+   * 商品详情页路径信息
+   */
+  @Data
+  public static class PagePath {
+    /**
+     * 商品详情半屏页、全屏页所属appid
+     */
+    private String appid;
+
+    /**
+     * 商品详情半屏页path
+     */
+    @JsonProperty("half_page_path")
+    private String halfPagePath;
+
+    /**
+     * 商品详情全屏页path
+     */
+    @JsonProperty("full_page_path")
+    private String fullPagePath;
+  }
+
+  /**
+   * 商品禁售原因及申请相关信息
+   */
+  @Data
+  public static class BannedDetails {
+    /**
+     * 禁售原因
+     * 0	三级类目在橱窗禁售 或 商品在来源处被禁售
+     * 1	商品属于可申请售卖的类目，但商家未完成申请
+     * 2	商品所属分店未处于营业状态
+     */
+    private Integer reason;
+
+    /**
+     * 需要申请的类目ID
+     */
+    @JsonProperty("need_apply_category_id")
+    private String needApplyCategoryId;
+
+    /**
+     * 需要申请的类目名
+     */
+    @JsonProperty("need_apply_category_name")
+    private String needApplyCategoryName;
+  }
+
+  /**
+   * 分店信息
+   */
+  @Data
+  public static class BranchInfo {
+    /**
+     * 分店ID
+     */
+    @JsonProperty("branch_id")
+    private Long branchId;
+
+    /**
+     * 分店名
+     */
+    @JsonProperty("branch_name")
+    private String branchName;
+
+    /**
+     * 分店状态
+     * 0	营业中
+     * 1	停业
+     */
+    @JsonProperty("branch_status")
+    private Integer branchStatus;
+  }
+
+  /**
+   * 抢购活动信息
+   */
+  @Data
+  public static class LimitDiscountInfo {
+    /**
+     * 是否有生效中的抢购活动
+     */
+    @JsonProperty("is_effect")
+    private Boolean isEffect;
+
+    /**
+     * 抢购价
+     */
+    @JsonProperty("discount_price")
+    private Long discountPrice;
+
+    /**
+     * 抢购活动结束时间(毫秒时间戳)
+     */
+    @JsonProperty("end_time_ms")
+    private String endTimeMs;
+
+    /**
+     * 抢购剩余库存
+     */
+    private Long stock;
+  }
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/constant/WxChannelApiUrlConstants.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/constant/WxChannelApiUrlConstants.java
@@ -351,4 +351,53 @@ public class WxChannelApiUrlConstants {
     /** 下架橱窗商品 */
     String OFF_WINDOW_PRODUCT_URL = "https://api.weixin.qq.com/channels/ec/window/product/off";
   }
+
+  /**
+   * 留资组件管理
+   */
+  public interface LeadComponent {
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_info_by_component_id.html">按时间获取留资信息详情</a>
+     */
+    String GET_LEADS_INFO_BY_COMPONENT_ID = "https://api.weixin.qq.com/channels/leads/get_leads_info_by_component_id";
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_info_by_request_id.html">按直播场次获取留资信息详情</a>
+     */
+    String GET_LEADS_INFO_BY_REQUEST_ID = "https://api.weixin.qq.com/channels/leads/get_leads_info_by_request_id";
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_request_id.html">获取留资request_id列表详情</a>
+     */
+    String GET_LEADS_REQUEST_ID = "https://api.weixin.qq.com/channels/leads/get_leads_request_id";
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_component_promote_record.html">获取留资组件直播推广记录信息详情</a>
+     */
+    String GET_LEADS_COMPONENT_PROMOTE_RECORD = "https://api.weixin.qq.com/channels/leads/get_leads_component_promote_record";
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_component_id.html">获取留资组件Id列表详情</a>
+     */
+    String GET_LEADS_COMPONENT_ID = "https://api.weixin.qq.com/channels/leads/get_leads_component_id";
+  }
+
+  /**
+   * 留资服务的直播数据
+   */
+  public interface FinderLive {
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/live/get_finder_attr_by_appid.html">获取视频号账号信息</a>
+     */
+    String GET_FINDER_ATTR_BY_APPID = "https://api.weixin.qq.com/channels/finderlive/get_finder_attr_by_appid";
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/live/get_finder_live_data_list.html">获取留资直播间数据详情</a>
+     */
+    String GET_FINDER_LIVE_DATA_LIST = "https://api.weixin.qq.com/channels/finderlive/get_finder_live_data_list";
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/live/get_finder_live_leads_data.html">获取账号收集的留资数量</a>
+     */
+    String GET_FINDER_LIVE_LEADS_DATA = "https://api.weixin.qq.com/channels/finderlive/get_finder_live_leads_data";
+  }
 }

--- a/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxAssistantServiceImplTest.java
+++ b/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxAssistantServiceImplTest.java
@@ -1,0 +1,65 @@
+package me.chanjar.weixin.channel.api.impl;
+
+import com.google.inject.Inject;
+import me.chanjar.weixin.channel.api.WxChannelService;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+import me.chanjar.weixin.channel.bean.window.request.AddWindowProductRequest;
+import me.chanjar.weixin.channel.bean.window.request.GetWindowProductListRequest;
+import me.chanjar.weixin.channel.bean.window.request.WindowProductRequest;
+import me.chanjar.weixin.channel.test.ApiTestModule;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author <a href="https://github.com/imyzt">imyzt</a>
+ */
+@Guice(modules = ApiTestModule.class)
+public class WxAssistantServiceImplTest {
+
+  @Inject
+  private WxChannelService channelService;
+
+  @Test
+  public void testAddWindowProduct() throws WxErrorException {
+    AddWindowProductRequest req = new AddWindowProductRequest();
+    req.setProductId("123");
+    req.setAppid(channelService.getConfig().getAppid());
+    req.setIsHideForWindow(true);
+    WxChannelBaseResponse response = channelService.getAssistantService().addWindowProduct(req);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+  @Test
+  public void testGetWindowProduct() throws WxErrorException {
+    WindowProductRequest req = new WindowProductRequest();
+    req.setProductId("123");
+    req.setAppid(channelService.getConfig().getAppid());
+    WxChannelBaseResponse response = channelService.getAssistantService().getWindowProduct(req);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+  @Test
+  public void testGetWindowProductList() throws WxErrorException {
+    GetWindowProductListRequest req = new GetWindowProductListRequest();
+    req.setAppid(channelService.getConfig().getAppid());
+    WxChannelBaseResponse response = channelService.getAssistantService().getWindowProductList(req);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+  @Test
+  public void testOffWindowProduct() throws WxErrorException {
+    WindowProductRequest req = new WindowProductRequest();
+    req.setProductId("123");
+    req.setAppid(channelService.getConfig().getAppid());
+    WxChannelBaseResponse response = channelService.getAssistantService().offWindowProduct(req);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+}

--- a/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxFinderLiveServiceImplTest.java
+++ b/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxFinderLiveServiceImplTest.java
@@ -1,0 +1,68 @@
+package me.chanjar.weixin.channel.api.impl;
+
+import com.google.inject.Inject;
+import me.chanjar.weixin.channel.api.WxChannelService;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetFinderLiveDataListRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetFinderLiveLeadsDataRequest;
+import me.chanjar.weixin.channel.bean.lead.component.response.FinderAttrResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetFinderLiveDataListResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetFinderLiveLeadsDataResponse;
+import me.chanjar.weixin.channel.test.ApiTestModule;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author <a href="https://github.com/imyzt">imyzt</a>
+ */
+@Guice(modules = ApiTestModule.class)
+public class WxFinderLiveServiceImplTest {
+
+  @Inject
+  private WxChannelService channelService;
+
+  @Test
+  public void testGetFinderAttrByAppid() throws WxErrorException {
+    FinderAttrResponse response = channelService.getFinderLiveService().getFinderAttrByAppid();
+    System.out.println(response);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+  @Test
+  public void testGetFinderLiveDataList() throws WxErrorException {
+    String lastBuffer = null;
+    for (; ; ) {
+      GetFinderLiveDataListRequest req = new GetFinderLiveDataListRequest();
+      req.setLastBuffer(lastBuffer);
+      GetFinderLiveDataListResponse response = channelService.getFinderLiveService().getFinderLiveDataList(req);
+      System.out.println(response);
+      assertNotNull(response);
+      assertTrue(response.isSuccess());
+      lastBuffer = response.getLastBuffer();
+      if (Objects.isNull(lastBuffer)) {
+        break;
+      }
+    }
+  }
+
+  @Test
+  public void testGetFinderLiveLeadsData() throws WxErrorException {
+    GetFinderLiveLeadsDataRequest req = new GetFinderLiveLeadsDataRequest();
+    req.setStartTime(Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond());
+    req.setEndTime(Instant.now().getEpochSecond());
+    GetFinderLiveLeadsDataResponse response = channelService.getFinderLiveService().getFinderLiveLeadsData(req);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+    for (GetFinderLiveLeadsDataResponse.LeadCountItem item : response.getItems()) {
+      System.out.println(item.toString());
+    }
+  }
+}

--- a/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxLeadComponentServiceImplTest.java
+++ b/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxLeadComponentServiceImplTest.java
@@ -1,0 +1,123 @@
+package me.chanjar.weixin.channel.api.impl;
+
+import com.google.inject.Inject;
+import me.chanjar.weixin.channel.api.WxChannelService;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadInfoByComponentRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsComponentIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsComponentPromoteRecordRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsInfoByRequestIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadsRequestIdRequest;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsComponentIdResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsComponentPromoteRecordResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.GetLeadsRequestIdResponse;
+import me.chanjar.weixin.channel.bean.lead.component.response.LeadInfoResponse;
+import me.chanjar.weixin.channel.test.ApiTestModule;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+/**
+ * @author <a href="https://github.com/imyzt">imyzt</a>
+ */
+@Guice(modules = ApiTestModule.class)
+public class WxLeadComponentServiceImplTest {
+
+  @Inject
+  private WxChannelService channelService;
+
+  @Test
+  public void testGetLeadsInfoByComponentId() throws WxErrorException {
+    String lastBuffer = null;
+    for (; ; ) {
+      GetLeadInfoByComponentRequest req = new GetLeadInfoByComponentRequest();
+      req.setStartTime(Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond());
+      req.setEndTime(Instant.now().getEpochSecond());
+      req.setLeadsComponentId("123");
+      req.setLastBuffer(lastBuffer);
+      LeadInfoResponse response = channelService.getLeadComponentService().getLeadsInfoByComponentId(req);
+      assertNotNull(response);
+      assertTrue(response.isSuccess());
+      lastBuffer = response.getLastBuffer();
+      if (Objects.isNull(lastBuffer)) {
+        break;
+      }
+    }
+  }
+
+  @Test
+  public void testGetLeadsInfoByRequestId() throws WxErrorException {
+    String lastBuffer = null;
+    for (; ; ) {
+      GetLeadsInfoByRequestIdRequest req = new GetLeadsInfoByRequestIdRequest();
+      req.setLastBuffer(lastBuffer);
+      req.setRequestId("123");
+      LeadInfoResponse response = channelService.getLeadComponentService().getLeadsInfoByRequestId(req);
+      assertNotNull(response);
+      assertTrue(response.isSuccess());
+      lastBuffer = response.getLastBuffer();
+      if (Objects.isNull(lastBuffer)) {
+        break;
+      }
+    }
+  }
+
+  @Test
+  public void testGetLeadsRequestId() throws WxErrorException {
+    String lastBuffer = null;
+    for (; ; ) {
+      GetLeadsRequestIdRequest req = new GetLeadsRequestIdRequest();
+      req.setLastBuffer(lastBuffer);
+      req.setLeadsComponentId("123");
+      GetLeadsRequestIdResponse response = channelService.getLeadComponentService().getLeadsRequestId(req);
+      assertNotNull(response);
+      assertTrue(response.isSuccess());
+      lastBuffer = response.getLastBuffer();
+      if (Objects.isNull(lastBuffer)) {
+        break;
+      }
+    }
+  }
+
+  @Test
+  public void testGetLeadsComponentPromoteRecord() throws WxErrorException {
+    String lastBuffer = null;
+    for (; ; ) {
+      GetLeadsComponentPromoteRecordRequest req = new GetLeadsComponentPromoteRecordRequest();
+      req.setStartTime(Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond());
+      req.setEndTime(Instant.now().getEpochSecond());
+      req.setLeadsComponentId("123");
+      req.setLastBuffer(lastBuffer);
+      GetLeadsComponentPromoteRecordResponse response = channelService.getLeadComponentService().getLeadsComponentPromoteRecord(req);
+      assertNotNull(response);
+      assertTrue(response.isSuccess());
+      lastBuffer = response.getLastBuffer();
+      if (Objects.isNull(lastBuffer)) {
+        break;
+      }
+    }
+  }
+
+  @Test
+  public void testGetLeadsComponentId() throws WxErrorException {
+    String lastBuffer = null;
+    for (; ; ) {
+      GetLeadsComponentIdRequest req = new GetLeadsComponentIdRequest();
+      req.setLastBuffer(lastBuffer);
+      GetLeadsComponentIdResponse response = channelService.getLeadComponentService().getLeadsComponentId(req);
+      System.out.println(response);
+      assertNotNull(response);
+      assertTrue(response.isSuccess());
+      lastBuffer = response.getLastBuffer();
+      if (Objects.isNull(lastBuffer)) {
+        break;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
补充视频号相关接口，[留资服务的直播数据](https://developers.weixin.qq.com/doc/channels/API/live/get_finder_attr_by_appid.html)、[留资组件管理](https://developers.weixin.qq.com/doc/channels/API/leads/get_leads_info_by_component_id.html)均已测试，[橱窗管理](https://developers.weixin.qq.com/doc/channels/API/windowproduct/add.html)没有对应已认证的账号测试，单测已写好。