### PR TITLE
标记废弃冗余的【获取用户encryptKey】接口

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaInternetService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaInternetService.java
@@ -24,12 +24,15 @@ public interface WxMaInternetService {
    *
    * @return {@link WxMaInternetResponse}
    * @throws WxErrorException
+   * @apiNote 推荐使用  {@link #getUserEncryptKey(java.lang.String, java.lang.String)}
    */
+  @Deprecated
   WxMaInternetResponse getUserEncryptKey(String openid, String signature, String sigMethod) throws WxErrorException;
 
   /**
    * <pre>
-   * 获取用户encryptKey。 会获取用户最近3次的key，每个key的存活时间为3600s。
+   * 获取用户encryptKey。
+   * @implNote 会获取用户最近3次的key，每个key的存活时间为3600s。
    * 文档地址：https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/internet/internet.getUserEncryptKey.html
    * 接口地址：POST https://api.weixin.qq.com/wxa/business/getuserencryptkey?access_token=ACCESS_TOKEN&openid=OPENID&signature=SIGNATURE&sig_method=hmac_sha256
    * @param openid 用户的openid

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaInternetServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaInternetServiceImplTest.java
@@ -7,9 +7,6 @@ import com.google.inject.Inject;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -23,27 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class WxMaInternetServiceImplTest {
   @Inject
   private WxMaService wxService;
-
-  private static String HMACSHA256(String data, String key) throws Exception {
-    Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
-    SecretKeySpec secret_key = new SecretKeySpec(key.getBytes("UTF-8"), "HmacSHA256");
-    sha256_HMAC.init(secret_key);
-    byte[] array = sha256_HMAC.doFinal(data.getBytes("UTF-8"));
-    StringBuilder sb = new StringBuilder();
-    for (byte item : array) {
-      sb.append(Integer.toHexString((item & 0xFF) | 0x100).substring(1, 3));
-    }
-    return sb.toString().toUpperCase();
-  }
-
-  @Test
-  public void testGetUserEncryptKey() throws Exception {
-    String openid = "ogu-84hVFTbTt-myGisQESoDJ6BM";
-    String signature = HMACSHA256("", "9ny8n3t0KULoi0deF7T9pw==");
-    String sigMethod = "hmac_sha256";
-    WxMaInternetResponse response = this.wxService.getInternetService().getUserEncryptKey(openid, signature, sigMethod);
-    assertThat(response).isNotNull();
-  }
 
   @Test
   public void testGetUserEncryptKey2() throws Exception {


### PR DESCRIPTION
原来四个参数的方法多余，标记待废弃，删除测试方法