### PR TITLE
【企业微信】修复会议邮件请求体继承父类错误

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/mail/WxCpMailMeetingSendRequest.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/mail/WxCpMailMeetingSendRequest.java
@@ -18,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Accessors(chain = true)
-public class WxCpMailMeetingSendRequest extends WxCpMailScheduleSendRequest implements Serializable {
+public class WxCpMailMeetingSendRequest extends WxCpMailCommonSendRequest implements Serializable {
   private static final long serialVersionUID = -4961279393895454138L;
 
   /**


### PR DESCRIPTION
fix：修复会议邮件请求体继承父类错误