### PR TITLE
【企业微信】客户群详情补充回state参数

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpUserExternalGroupChatInfo.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/external/WxCpUserExternalGroupChatInfo.java
@@ -122,6 +122,12 @@ public class WxCpUserExternalGroupChatInfo extends WxCpBaseResp {
     private int joinScene;
 
     /**
+     * 该成员入群方式对应的state参数。仅限通过带有state的入群方式入群时会返回该值。
+     */
+    @SerializedName("state")
+    private String state;
+
+    /**
      * 邀请者。目前仅当是由本企业内部成员邀请入群时会返回该值
      */
     @SerializedName("invitor")


### PR DESCRIPTION
该提交移除了客户群详情中的state参数，根据文档说明，配置了带state入群参数时依然会有该参数存在。
https://github.com/Wechat-Group/WxJava/commit/04a679cdd758f4ecfeafb7afeb580ea66e097064#diff-fbb29edb5ac6bd7606e020804cc205b6cb0e4897906ceeaa82f7f86996ca1c45L97

文档：https://developer.work.weixin.qq.com/document/path/92229