### PR TITLE
:bug: #3265【视频号】视频号线索[获取留资信息详情]接口，兼容新版本返回的更多详细字段

### DIFF
--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadInfoByComponentRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadInfoByComponentRequest.java
@@ -43,9 +43,10 @@ public class GetLeadInfoByComponentRequest {
   private String lastBuffer;
 
   /**
-   * 接口版本号
+   * 接口版本号,默认=1
+   * =null和=1,微信返回的结构不一样,=1信息更全
    */
   @JsonProperty("version")
-  private int version;
+  private Integer version;
 
 }

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsInfoByRequestIdRequest.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/request/GetLeadsInfoByRequestIdRequest.java
@@ -31,9 +31,10 @@ public class GetLeadsInfoByRequestIdRequest {
   private String lastBuffer;
 
   /**
-   * 接口版本号
+   * 接口版本号,默认=1
+   * =null和=1,微信返回的结构不一样,=1信息更全
    */
   @JsonProperty("version")
-  private int version;
+  private Integer version;
 
 }

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/LeadInfoResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/lead/component/response/LeadInfoResponse.java
@@ -44,10 +44,47 @@ public class LeadInfoResponse extends WxChannelBaseResponse {
   @NoArgsConstructor
   public static class UserData {
 
+    /**
+     * 主播昵称
+     */
+    @JsonProperty("anchor_nickname")
+    private String anchorNickname;
+
+    /**
+     * 直播开始时间
+     */
+    @JsonProperty("live_start_time")
+    private Long liveStartTime;
+
+    /**
+     * 	用户留资信息列表
+     */
+    @JsonProperty("leads_data")
+    private List<LeadsData> leadsData;
+
+    /**
+     * 用户留资时间
+     */
+    @JsonProperty("time")
+    private Long time;
+
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class LeadsData {
+
+    /**
+     * 表单名称
+     */
     @JsonProperty("title")
     private String title;
 
+    /**
+     * 手机号,文本框,单选框时, 均为字符串
+     * 仅当title=城市 时, 微信返回字符串数组, eg: ["北京市","北京市","东城区"]
+     */
     @JsonProperty("value")
-    private String value;
+    private Object value;
   }
 }

--- a/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxLeadComponentServiceImplTest.java
+++ b/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxLeadComponentServiceImplTest.java
@@ -1,5 +1,7 @@
 package me.chanjar.weixin.channel.api.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import me.chanjar.weixin.channel.api.WxChannelService;
 import me.chanjar.weixin.channel.bean.lead.component.request.GetLeadInfoByComponentRequest;
@@ -28,19 +30,24 @@ import static org.testng.Assert.assertTrue;
 @Guice(modules = ApiTestModule.class)
 public class WxLeadComponentServiceImplTest {
 
+  private static final String LEADS_COMPONENT_ID = "123";
+  private static final String REQUEST_ID = "123";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @Inject
   private WxChannelService channelService;
 
   @Test
-  public void testGetLeadsInfoByComponentId() throws WxErrorException {
+  public void testGetLeadsInfoByComponentId() throws WxErrorException, JsonProcessingException {
     String lastBuffer = null;
     for (; ; ) {
       GetLeadInfoByComponentRequest req = new GetLeadInfoByComponentRequest();
       req.setStartTime(Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond());
       req.setEndTime(Instant.now().getEpochSecond());
-      req.setLeadsComponentId("123");
+      req.setLeadsComponentId(LEADS_COMPONENT_ID);
       req.setLastBuffer(lastBuffer);
+      req.setVersion(1);
       LeadInfoResponse response = channelService.getLeadComponentService().getLeadsInfoByComponentId(req);
+      System.out.println(OBJECT_MAPPER.writeValueAsString(response));
       assertNotNull(response);
       assertTrue(response.isSuccess());
       lastBuffer = response.getLastBuffer();
@@ -51,13 +58,14 @@ public class WxLeadComponentServiceImplTest {
   }
 
   @Test
-  public void testGetLeadsInfoByRequestId() throws WxErrorException {
+  public void testGetLeadsInfoByRequestId() throws WxErrorException, JsonProcessingException {
     String lastBuffer = null;
     for (; ; ) {
       GetLeadsInfoByRequestIdRequest req = new GetLeadsInfoByRequestIdRequest();
       req.setLastBuffer(lastBuffer);
-      req.setRequestId("123");
+      req.setRequestId(REQUEST_ID);
       LeadInfoResponse response = channelService.getLeadComponentService().getLeadsInfoByRequestId(req);
+      System.out.println(OBJECT_MAPPER.writeValueAsString(response));
       assertNotNull(response);
       assertTrue(response.isSuccess());
       lastBuffer = response.getLastBuffer();
@@ -68,13 +76,14 @@ public class WxLeadComponentServiceImplTest {
   }
 
   @Test
-  public void testGetLeadsRequestId() throws WxErrorException {
+  public void testGetLeadsRequestId() throws WxErrorException, JsonProcessingException {
     String lastBuffer = null;
     for (; ; ) {
       GetLeadsRequestIdRequest req = new GetLeadsRequestIdRequest();
       req.setLastBuffer(lastBuffer);
-      req.setLeadsComponentId("123");
+      req.setLeadsComponentId(LEADS_COMPONENT_ID);
       GetLeadsRequestIdResponse response = channelService.getLeadComponentService().getLeadsRequestId(req);
+      System.out.println(OBJECT_MAPPER.writeValueAsString(response));
       assertNotNull(response);
       assertTrue(response.isSuccess());
       lastBuffer = response.getLastBuffer();
@@ -85,15 +94,16 @@ public class WxLeadComponentServiceImplTest {
   }
 
   @Test
-  public void testGetLeadsComponentPromoteRecord() throws WxErrorException {
+  public void testGetLeadsComponentPromoteRecord() throws WxErrorException, JsonProcessingException {
     String lastBuffer = null;
     for (; ; ) {
       GetLeadsComponentPromoteRecordRequest req = new GetLeadsComponentPromoteRecordRequest();
       req.setStartTime(Instant.now().minus(1, ChronoUnit.DAYS).getEpochSecond());
       req.setEndTime(Instant.now().getEpochSecond());
-      req.setLeadsComponentId("123");
+      req.setLeadsComponentId(LEADS_COMPONENT_ID);
       req.setLastBuffer(lastBuffer);
       GetLeadsComponentPromoteRecordResponse response = channelService.getLeadComponentService().getLeadsComponentPromoteRecord(req);
+      System.out.println(OBJECT_MAPPER.writeValueAsString(response));
       assertNotNull(response);
       assertTrue(response.isSuccess());
       lastBuffer = response.getLastBuffer();
@@ -104,13 +114,13 @@ public class WxLeadComponentServiceImplTest {
   }
 
   @Test
-  public void testGetLeadsComponentId() throws WxErrorException {
+  public void testGetLeadsComponentId() throws WxErrorException, JsonProcessingException {
     String lastBuffer = null;
     for (; ; ) {
       GetLeadsComponentIdRequest req = new GetLeadsComponentIdRequest();
       req.setLastBuffer(lastBuffer);
       GetLeadsComponentIdResponse response = channelService.getLeadComponentService().getLeadsComponentId(req);
-      System.out.println(response);
+      System.out.println(OBJECT_MAPPER.writeValueAsString(response));
       assertNotNull(response);
       assertTrue(response.isSuccess());
       lastBuffer = response.getLastBuffer();


### PR DESCRIPTION
1. 视频号留资信息，返回对象适配更详细的新接口。
2. 补充完整的返回参数映射，避免其他人重复踩坑。
