### PR TITLE
:bug: #3258【微信支付】解决部分金额字段整数溢出问题

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/marketing/FavorCouponsGetResult.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/marketing/FavorCouponsGetResult.java
@@ -171,7 +171,7 @@ public class FavorCouponsGetResult implements Serializable {
      * 示例值：100
      */
     @SerializedName(value = "single_price_max")
-    private Integer singlePriceMax;
+    private Long singlePriceMax;
 
     /**
      * 减至后的优惠单价
@@ -180,7 +180,7 @@ public class FavorCouponsGetResult implements Serializable {
      * 示例值：100
      */
     @SerializedName(value = "cut_to_price")
-    private Integer cutToPrice;
+    private Long cutToPrice;
   }
 
   @Data

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/marketing/FavorCouponsUseResult.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/marketing/FavorCouponsUseResult.java
@@ -179,7 +179,7 @@ public class FavorCouponsUseResult implements Serializable {
      * 示例值：100
      */
     @SerializedName(value = "single_price_max")
-    private Integer singlePriceMax;
+    private Long singlePriceMax;
   }
 
   @Data
@@ -194,7 +194,7 @@ public class FavorCouponsUseResult implements Serializable {
      * 示例值：100
      */
     @SerializedName(value = "cut_to_price")
-    private Integer cutToPrice;
+    private Long cutToPrice;
 
     /**
      * 最高价格
@@ -203,7 +203,7 @@ public class FavorCouponsUseResult implements Serializable {
      * 示例值：20
      */
     @SerializedName(value = "max_price")
-    private Integer maxPrice;
+    private Long maxPrice;
   }
 
   @Data
@@ -218,7 +218,7 @@ public class FavorCouponsUseResult implements Serializable {
      * 示例值：100
      */
     @SerializedName(value = "coupon_amount")
-    private Integer couponAmount;
+    private Long couponAmount;
 
     /**
      * 门槛
@@ -227,7 +227,7 @@ public class FavorCouponsUseResult implements Serializable {
      * 示例值：100
      */
     @SerializedName(value = "transaction_minimum")
-    private Integer transactionMinimum;
+    private Long transactionMinimum;
   }
 
   @Data

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/marketing/FavorStocksQueryResult.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/marketing/FavorStocksQueryResult.java
@@ -25,7 +25,7 @@ public class FavorStocksQueryResult implements Serializable {
    * 示例值：10
    */
   @SerializedName("total_count")
-  private Integer totalCount;
+  private Long totalCount;
 
   /**
    * 批次详情


### PR DESCRIPTION
解决部分字段`uint64`、`int64`映射到Java的`Integer`导致的整数溢出。

1. [核销事件回调通知API](https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter9_1_15.shtml)
<img width="802" alt="image" src="https://github.com/Wechat-Group/WxJava/assets/28680198/82831c85-71b7-4edb-982c-4065aecfab3c">

2. [查询代金券详情](https://pay.weixin.qq.com/wiki/doc/apiv3/wxpay/marketing/convention/chapter3_6.shtml)
<img width="804" alt="image" src="https://github.com/Wechat-Group/WxJava/assets/28680198/cac2a10c-4e44-4cc6-b066-f4108f687ee3">

3. [条件查询批次列表API](https://pay.weixin.qq.com/wiki/doc/apiv3/wxpay/marketing/convention/chapter3_4.shtml)
<img width="840" alt="image" src="https://github.com/Wechat-Group/WxJava/assets/28680198/636795e1-00cb-44d6-8108-028864e65086">
