### PR TITLE
:art: #3270【开放平台】同步官方获取授权方选项信息、设置授权方选项信息接口地址

### DIFF
--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
@@ -55,13 +55,13 @@ public interface WxOpenComponentService {
    */
   String API_GET_AUTHORIZER_INFO_URL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_info";
   /**
-   * The constant API_GET_AUTHORIZER_OPTION_URL.
+   * The constant GET_AUTHORIZER_OPTION_URL.
    */
-  String API_GET_AUTHORIZER_OPTION_URL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_option";
+  String GET_AUTHORIZER_OPTION_URL = "https://api.weixin.qq.com/cgi-bin/component/get_authorizer_option";
   /**
-   * The constant API_SET_AUTHORIZER_OPTION_URL.
+   * The constant SET_AUTHORIZER_OPTION_URL.
    */
-  String API_SET_AUTHORIZER_OPTION_URL = "https://api.weixin.qq.com/cgi-bin/component/api_set_authorizer_option";
+  String SET_AUTHORIZER_OPTION_URL = "https://api.weixin.qq.com/cgi-bin/component/set_authorizer_option";
   /**
    * The constant API_GET_AUTHORIZER_LIST.
    */
@@ -202,6 +202,7 @@ public interface WxOpenComponentService {
   String BATCH_SHARE_ENV = "https://api.weixin.qq.com/componenttcb/batchshareenv";
 
   String COMPONENT_CLEAR_QUOTA_URL = "https://api.weixin.qq.com/cgi-bin/component/clear_quota/v2";
+
   /**
    * Gets wx mp service by appid.
    *
@@ -1092,7 +1093,7 @@ public interface WxOpenComponentService {
    * 使用 AppSecret 重置第三方平台 API 调用次数
    * https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/openapi/clearComponentQuotaByAppSecret.html
    *
-   * @param appid  授权用户appid
+   * @param appid 授权用户appid
    * @return
    * @throws WxErrorException
    */

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
@@ -402,7 +402,7 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
     jsonObject.addProperty("component_appid", getWxOpenConfigStorage().getComponentAppId());
     jsonObject.addProperty("authorizer_appid", authorizerAppid);
     jsonObject.addProperty("option_name", optionName);
-    String responseContent = post(API_GET_AUTHORIZER_OPTION_URL, jsonObject.toString());
+    String responseContent = post(GET_AUTHORIZER_OPTION_URL, jsonObject.toString());
     return WxOpenGsonBuilder.create().fromJson(responseContent, WxOpenAuthorizerOptionResult.class);
   }
 
@@ -413,7 +413,7 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
     jsonObject.addProperty("authorizer_appid", authorizerAppid);
     jsonObject.addProperty("option_name", optionName);
     jsonObject.addProperty("option_value", optionValue);
-    post(API_SET_AUTHORIZER_OPTION_URL, jsonObject.toString());
+    post(SET_AUTHORIZER_OPTION_URL, jsonObject.toString());
   }
 
   @Override


### PR DESCRIPTION
开放平台官方修改了接口地址
获取授权方选项信息接口地址官方文档地址：https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/authorization-management/getAuthorizerOptionInfo.html
设置授权方选项信息接口官方文档地址：https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/authorization-management/setAuthorizerOptionInfo.html