### PR TITLE
【公众号】再次修复HttpClient发送文件上传请求时Content-Type没有boundary的问题

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/requestexecuter/material/MaterialUploadApacheHttpRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/requestexecuter/material/MaterialUploadApacheHttpRequestExecutor.java
@@ -58,11 +58,7 @@ public class MaterialUploadApacheHttpRequestExecutor extends MaterialUploadReque
       multipartEntityBuilder.addPart("description",
         new StringBody(WxGsonBuilder.create().toJson(form), ContentType.create("text/plain", Consts.UTF_8)));
     }
-
     httpPost.setEntity(multipartEntityBuilder.build());
-    //手动设置的Content-Type请求头没有boundary，是一个非标准的文件上传请求头，虽然微信提供了对这类非标准请求的支持，但如果请求需要先经过我们的tomcat server，那么都会报错:the request was rejected because no multipart boundary was found
-    //不设置Content-Type请求头，httpclient将会自动设置，值为entity的getContentType方法返回值。MultipartEntityBuilder的getContentType方法将会返回boundary
-    //httpPost.setHeader("Content-Type", ContentType.MULTIPART_FORM_DATA.toString());
 
     try (CloseableHttpResponse response = requestHttp.getRequestHttpClient().execute(httpPost)) {
       String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/requestexecuter/material/MaterialUploadApacheHttpRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/requestexecuter/material/MaterialUploadApacheHttpRequestExecutor.java
@@ -60,7 +60,9 @@ public class MaterialUploadApacheHttpRequestExecutor extends MaterialUploadReque
     }
 
     httpPost.setEntity(multipartEntityBuilder.build());
-    httpPost.setHeader("Content-Type", ContentType.MULTIPART_FORM_DATA.toString());
+    //手动设置的Content-Type请求头没有boundary，是一个非标准的文件上传请求头，虽然微信提供了对这类非标准请求的支持，但如果请求需要先经过我们的tomcat server，那么都会报错:the request was rejected because no multipart boundary was found
+    //不设置Content-Type请求头，httpclient将会自动设置，值为entity的getContentType方法返回值。MultipartEntityBuilder的getContentType方法将会返回boundary
+    //httpPost.setHeader("Content-Type", ContentType.MULTIPART_FORM_DATA.toString());
 
     try (CloseableHttpResponse response = requestHttp.getRequestHttpClient().execute(httpPost)) {
       String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/requestexecuter/media/MediaImgUploadApacheHttpRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/requestexecuter/media/MediaImgUploadApacheHttpRequestExecutor.java
@@ -47,7 +47,6 @@ public class MediaImgUploadApacheHttpRequestExecutor extends MediaImgUploadReque
       .setMode(HttpMultipartMode.RFC6532)
       .build();
     httpPost.setEntity(entity);
-    httpPost.setHeader("Content-Type", ContentType.MULTIPART_FORM_DATA.toString());
 
     try (CloseableHttpResponse response = requestHttp.getRequestHttpClient().execute(httpPost)) {
       String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/requestexecuter/voice/VoiceUploadApacheHttpRequestExecutor.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/requestexecuter/voice/VoiceUploadApacheHttpRequestExecutor.java
@@ -48,7 +48,6 @@ public class VoiceUploadApacheHttpRequestExecutor extends VoiceUploadRequestExec
       .setMode(HttpMultipartMode.RFC6532)
       .build();
     httpPost.setEntity(entity);
-    httpPost.setHeader("Content-Type", ContentType.MULTIPART_FORM_DATA.toString());
 
     try (CloseableHttpResponse response = requestHttp.getRequestHttpClient().execute(httpPost)) {
       String responseContent = Utf8ResponseHandler.INSTANCE.handleResponse(response);


### PR DESCRIPTION
上次的pr（#3282）只修改了MaterialUploadApacheHttpRequestExecutor类发送文件上传请求的问题，后面发现还有几个类也存在同样的问题，故一起修复提交