### PR TITLE
增加临时素材上传重载

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMediaService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMediaService.java
@@ -54,6 +54,32 @@ public interface WxCpMediaService {
     throws WxErrorException, IOException;
 
   /**
+   * <pre>
+   *   上传多媒体文件.
+   * </pre>
+   *
+   * @param mediaType 媒体类型, 请看{@link me.chanjar.weixin.common.api.WxConsts}
+   * @param file      文件对象, 上传的文件内容
+   * @param filename  上传内容的实际文件名.例如：wework.txt
+   * @return wx media upload result
+   * @throws WxErrorException the wx error exception
+   */
+  WxMediaUploadResult upload(String mediaType, File file, String filename) throws WxErrorException;
+
+  /**
+   * <pre>
+   *   上传多媒体文件.
+   * </pre>
+   *
+   * @param mediaType   媒体类型, 请看{@link me.chanjar.weixin.common.api.WxConsts}
+   * @param inputStream 上传的文件内容
+   * @param filename    上传内容的实际文件名.例如：wework.txt
+   * @return wx media upload result
+   * @throws WxErrorException the wx error exception
+   */
+  WxMediaUploadResult upload(String mediaType, InputStream inputStream, String filename) throws WxErrorException;
+
+  /**
    * 上传多媒体文件.
    *
    * @param mediaType 媒体类型


### PR DESCRIPTION
企微客服发送文件消息的接口中需要使用临时素材上传接口，如果临时素材上传的时候不指定文件名，则客户看到的文件名会是随机生成的，目前提供的API中临时素材上传接口要指定文件名只能使用外部的多媒体素材 url ，所以想要增加一个消息的重载，使用 InputStream 或者 File 类型 并指定名称进行素材上传。
想提供一个签名如下的方法来实现本地文件上传并指定素材名称
```
WxMediaUploadResult upload(String mediaType, File file, String filename) throws WxErrorException;
WxMediaUploadResult upload(String mediaType, InputStream inputStream,String filename) throws WxErrorException;
```