### PR TITLE
fixbug:新增字段status至WxMaVodDramaInfo类以支持审核状态展示

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/vod/WxMaVodDramaInfo.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/bean/vod/WxMaVodDramaInfo.java
@@ -36,6 +36,8 @@ public class WxMaVodDramaInfo implements Serializable {
   private String productionLicense;
   @SerializedName("description")
   private String description;
+  @SerializedName("status")
+  private String status;
 
   @SerializedName("audit_detail")
   private DramaAuditDetail auditDetail;


### PR DESCRIPTION
为了使WxMaVodDramaInfo类能展示更多的信息，我们新增了一个字段`status`，这将有助于详细了解剧集的审核状态。此更改涉及到序列化和反序列化操作，以确保数据的正确处理。
issues:https://github.com/Wechat-Group/WxJava/issues/3343