### PR TITLE
【视频号】新增视频号助手-直播大屏数据、罗盘达人版API接口相关内容。

### DIFF
--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxChannelCompassFinderService.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxChannelCompassFinderService.java
@@ -1,0 +1,58 @@
+package me.chanjar.weixin.channel.api;
+
+import me.chanjar.weixin.channel.bean.compass.finder.OverallResponse;
+import me.chanjar.weixin.channel.bean.compass.finder.ProductDataResponse;
+import me.chanjar.weixin.channel.bean.compass.finder.ProductListResponse;
+import me.chanjar.weixin.channel.bean.compass.finder.SaleProfileDataResponse;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+/**
+ * 视频号助手 罗盘达人版服务
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+public interface WxChannelCompassFinderService {
+
+  /**
+   * 获取电商概览数据
+   *
+   * @param ds 日期，格式 yyyyMMdd
+   * @return 电商概览数据
+   *
+   * @throws WxErrorException 异常
+   */
+  OverallResponse getOverall(String ds) throws WxErrorException;
+
+  /**
+   * 获取带货商品数据
+   *
+   * @param ds        日期，格式 yyyyMMdd
+   * @param productId 商品id
+   * @return 带货商品数据
+   *
+   * @throws WxErrorException 异常
+   */
+  ProductDataResponse getProductData(String ds, String productId) throws WxErrorException;
+
+  /**
+   * 获取带货商品列表
+   *
+   * @param ds 日期，格式 yyyyMMdd
+   * @return 带货商品列表
+   *
+   * @throws WxErrorException 异常
+   */
+  ProductListResponse getProductList(String ds) throws WxErrorException;
+
+  /**
+   * 获取带货人群数据
+   *
+   * @param ds   日期，格式 yyyyMMdd
+   * @param type 用户类型，1=商品曝光用户, 2=商品点击用户, 3=购买用户, 4=首购用户, 5=复购用户, 6=直播观看用户
+   * @return 带货人群数据
+   *
+   * @throws WxErrorException 异常
+   */
+  SaleProfileDataResponse getSaleProfileData(String ds, Integer type) throws WxErrorException;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxChannelLiveDashboardService.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxChannelLiveDashboardService.java
@@ -1,0 +1,34 @@
+package me.chanjar.weixin.channel.api;
+
+import me.chanjar.weixin.channel.bean.live.dashboard.LiveDataResponse;
+import me.chanjar.weixin.channel.bean.live.dashboard.LiveListResponse;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+/**
+ * 视频号助手 直播大屏数据服务
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+public interface WxChannelLiveDashboardService {
+
+  /**
+   * 获取直播大屏直播列表
+   *
+   * @param ds 日期，格式 yyyyMMdd
+   * @return 播大屏直播列表
+   *
+   * @throws WxErrorException 异常
+   */
+  LiveListResponse getLiveList(Long ds) throws WxErrorException;
+
+  /**
+   * 获取直播大屏数据
+   *
+   * @param exportId 直播唯一ID
+   * @return 播大屏数据
+   *
+   * @throws WxErrorException 异常
+   */
+  LiveDataResponse getLiveData(String exportId) throws WxErrorException;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxChannelService.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/WxChannelService.java
@@ -147,4 +147,19 @@ public interface WxChannelService extends BaseWxChannelService {
    * @return 会员服务
    */
   WxChannelVipService getVipService();
+
+  /**
+   * 视频号助手-罗盘达人版服务
+   *
+   * @return 罗盘达人版服务
+   */
+  WxChannelCompassFinderService getCompassFinderService();
+
+  /**
+   * 视频号助手-直播大屏数据服务
+   *
+   * @return 直播大屏数据服务
+   */
+  WxChannelLiveDashboardService getLiveDashboardService();
+
 }

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/BaseWxChannelServiceImpl.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/BaseWxChannelServiceImpl.java
@@ -55,6 +55,10 @@ public abstract class BaseWxChannelServiceImpl<H, P> implements WxChannelService
   private WxFinderLiveService finderLiveService = null;
   private WxAssistantService assistantService = null;
   private WxChannelVipService vipService = new WxChannelVipServiceImpl(this);
+  private final WxChannelCompassFinderService compassFinderService =
+    new WxChannelCompassFinderServiceImpl(this);
+  private final WxChannelLiveDashboardService liveDashboardService =
+    new WxChannelLiveDashboardServiceImpl(this);
 
   protected WxChannelConfig config;
   private int retrySleepMillis = 1000;
@@ -411,4 +415,11 @@ public abstract class BaseWxChannelServiceImpl<H, P> implements WxChannelService
   public WxChannelVipService getVipService() {
     return vipService;
   }
+
+  @Override
+  public WxChannelCompassFinderService getCompassFinderService() { return compassFinderService; }
+
+  @Override
+  public WxChannelLiveDashboardService getLiveDashboardService() { return liveDashboardService; }
+
 }

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxChannelCompassFinderServiceImpl.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxChannelCompassFinderServiceImpl.java
@@ -1,0 +1,54 @@
+package me.chanjar.weixin.channel.api.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.channel.api.WxChannelCompassFinderService;
+import me.chanjar.weixin.channel.bean.compass.finder.*;
+import me.chanjar.weixin.channel.util.ResponseUtils;
+import me.chanjar.weixin.common.error.WxErrorException;
+
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.CompassFinder.*;
+
+/**
+ * 视频号助手 罗盘达人版服务实现
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Slf4j
+public class WxChannelCompassFinderServiceImpl implements WxChannelCompassFinderService {
+
+  /**
+   * 微信商店服务
+   */
+  private final BaseWxChannelServiceImpl shopService;
+
+  public WxChannelCompassFinderServiceImpl(BaseWxChannelServiceImpl shopService) {this.shopService = shopService;}
+
+  @Override
+  public OverallResponse getOverall(String ds) throws WxErrorException {
+    CompassFinderBaseParam param = new CompassFinderBaseParam(ds);
+    String resJson = shopService.post(GET_OVERALL_URL, param);
+    return ResponseUtils.decode(resJson, OverallResponse.class);
+  }
+
+  @Override
+  public ProductDataResponse getProductData(String ds, String productId) throws WxErrorException {
+    ProductDataParam param = new ProductDataParam(ds, productId);
+    String resJson = shopService.post(GET_PRODUCT_DATA_URL, param);
+    return ResponseUtils.decode(resJson, ProductDataResponse.class);
+  }
+
+  @Override
+  public ProductListResponse getProductList(String ds) throws WxErrorException {
+    CompassFinderBaseParam param = new CompassFinderBaseParam(ds);
+    String resJson = shopService.post(GET_PRODUCT_LIST_URL, param);
+    return ResponseUtils.decode(resJson, ProductListResponse.class);
+  }
+
+  @Override
+  public SaleProfileDataResponse getSaleProfileData(String ds, Integer type) throws WxErrorException {
+    SaleProfileDataParam param = new SaleProfileDataParam(ds, type);
+    String resJson = shopService.post(GET_SALE_PROFILE_DATA_URL, param);
+    return ResponseUtils.decode(resJson, SaleProfileDataResponse.class);
+  }
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxChannelLiveDashboardServiceImpl.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxChannelLiveDashboardServiceImpl.java
@@ -1,0 +1,81 @@
+package me.chanjar.weixin.channel.api.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import me.chanjar.weixin.channel.api.WxChannelLiveDashboardService;
+import me.chanjar.weixin.channel.bean.live.dashboard.LiveDataParam;
+import me.chanjar.weixin.channel.bean.live.dashboard.LiveDataResponse;
+import me.chanjar.weixin.channel.bean.live.dashboard.LiveListParam;
+import me.chanjar.weixin.channel.bean.live.dashboard.LiveListResponse;
+import me.chanjar.weixin.channel.util.ResponseUtils;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.apache.commons.lang3.ObjectUtils;
+
+import static me.chanjar.weixin.channel.constant.WxChannelApiUrlConstants.LiveDashboard.*;
+
+/**
+ * 视频号助手 直播大屏数据服务实现
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Slf4j
+public class WxChannelLiveDashboardServiceImpl implements WxChannelLiveDashboardService {
+
+  /**
+   * 微信商店服务
+   */
+  private final BaseWxChannelServiceImpl shopService;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public WxChannelLiveDashboardServiceImpl(BaseWxChannelServiceImpl shopService) {this.shopService = shopService;}
+
+  @Override
+  public LiveListResponse getLiveList(Long ds) throws WxErrorException {
+    LiveListParam param = new LiveListParam(ds);
+    String resJson = shopService.post(GET_LIVE_LIST_URL, param);
+    return ResponseUtils.decode(resJson, LiveListResponse.class);
+  }
+
+  @Override
+  public LiveDataResponse getLiveData(String exportId) throws WxErrorException {
+    LiveDataParam param = new LiveDataParam(exportId);
+    String resJson = shopService.post(GET_LIVE_DATA_URL, param);
+    return this.convertLiveDataResponse(resJson);
+  }
+
+  /**
+   * 微信接口获取直播数据中存在非标准JSON，方便业务处理返回前做好解析
+   *    处理参数：
+   *    live_dashboard_data，live_comparison_index，live_ec_data_summary，live_ec_conversion_metric，
+   *    live_ec_profile，live_distribution_channel，single_live_ec_spu_data_page_v2
+   *
+   * @param resJson 直播数据返回JSON
+   * @return LiveDataResponse
+   *
+   * @throws WxErrorException 异常
+   */
+  private LiveDataResponse convertLiveDataResponse(String resJson) throws WxErrorException {
+    try {
+      ObjectNode rootNode = (ObjectNode) objectMapper.readTree(resJson);
+      String[] dataKeyArray = new String[] {
+        "live_dashboard_data", "live_comparison_index", "live_ec_data_summary", "live_ec_conversion_metric",
+        "live_ec_profile", "live_distribution_channel", "single_live_ec_spu_data_page_v2"
+      };
+      for(String dataKey : dataKeyArray) {
+        JsonNode jsonNode = rootNode.get(dataKey);
+        if (ObjectUtils.isNotEmpty(jsonNode)) {
+          JsonNode dataJsonNode = objectMapper.readTree(jsonNode.asText());
+          rootNode.set(dataKey, dataJsonNode);
+        }
+      }
+      String json = objectMapper.writeValueAsString(rootNode);
+      return ResponseUtils.decode(json, LiveDataResponse.class);
+    } catch (JsonProcessingException e) {
+      throw new WxErrorException(e);
+    }
+  }
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/CompassFinderBaseParam.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/CompassFinderBaseParam.java
@@ -1,0 +1,30 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 获取达人罗盘数据通用请求参数
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CompassFinderBaseParam implements Serializable {
+
+  private static final long serialVersionUID = - 4900361041041434435L;
+
+  /**
+   * 日期，格式 yyyyMMdd
+   */
+  @JsonProperty("ds")
+  private String ds;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/Field.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/Field.java
@@ -1,0 +1,33 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 维度数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class Field implements Serializable {
+
+  private static final long serialVersionUID = - 4243469984232948689L;
+
+  /**
+   * 维度类别名
+   */
+  @JsonProperty("field_name")
+  private String fieldName;
+
+  /**
+   * 维度指标数据列表
+   */
+  @JsonProperty("data_list")
+  private List<FieldData> dataList;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/FieldData.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/FieldData.java
@@ -1,0 +1,32 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 维度指标数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class FieldData implements Serializable {
+
+  private static final long serialVersionUID = - 4022953139259283599L;
+
+  /**
+   * 维度指标名
+   */
+  @JsonProperty("dim_key")
+  private String dimKey;
+
+  /**
+   * 维度指标值
+   */
+  @JsonProperty("dim_value")
+  private String dimValue;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/Overall.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/Overall.java
@@ -1,0 +1,56 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 电商概览数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class Overall implements Serializable {
+
+  private static final long serialVersionUID = 2456038666608345011L;
+
+  /**
+   * 成交金额，单位分
+   */
+  @JsonProperty("pay_gmv")
+  private String payGmv;
+
+  /**
+   * 直播成交金额，单位分
+   */
+  @JsonProperty("live_pay_gmv")
+  private String livePayGmv;
+
+  /**
+   * 短视频成交金额，单位分
+   */
+  @JsonProperty("feed_pay_gmv")
+  private String feedPayGmv;
+
+  /**
+   * 橱窗成交金额，单位分
+   */
+  @JsonProperty("window_pay_gmv")
+  private String windowPayGmv;
+
+  /**
+   * 商品分享支付金额，单位分
+   */
+  @JsonProperty("product_pay_gmv")
+  private String productPayGmv;
+
+  /**
+   * 其他渠道成交金额，单位分
+   */
+  @JsonProperty("other_pay_gmv")
+  private String otherPayGmv;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/OverallResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/OverallResponse.java
@@ -1,0 +1,27 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+/**
+ * 获取电商概览数据响应
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class OverallResponse extends WxChannelBaseResponse {
+
+  private static final long serialVersionUID = 6350218415876820956L;
+
+  /**
+   * 电商概览数据
+   */
+  @JsonProperty("data")
+  private Overall data;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductCompassData.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductCompassData.java
@@ -1,0 +1,170 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 商品罗盘数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class ProductCompassData implements Serializable {
+
+  private static final long serialVersionUID = - 1009289493985863096L;
+
+  /**
+   * 成交金额
+   */
+  @JsonProperty("pay_gmv")
+  private String payGmv;
+
+  /**
+   * 下单金额（单位：分）
+   */
+  @JsonProperty("create_gmv")
+  private String createGmv;
+
+  /**
+   * 下单订单数
+   */
+  @JsonProperty("create_cnt")
+  private String createCnt;
+
+  /**
+   * 下单人数
+   */
+  @JsonProperty("create_uv")
+  private String createUv;
+
+  /**
+   * 下单件数
+   */
+  @JsonProperty("create_product_cnt")
+  private String createProductCnt;
+
+  /**
+   * 成交订单数
+   */
+  @JsonProperty("pay_cnt")
+  private String payCnt;
+
+  /**
+   * 成交人数
+   */
+  @JsonProperty("pay_uv")
+  private String payUv;
+
+  /**
+   * 成交件数
+   */
+  @JsonProperty("pay_product_cnt")
+  private String payProductCnt;
+
+  /**
+   * 成交金额（剔除退款）（单位：分）
+   */
+  @JsonProperty("pure_pay_gmv")
+  private String purePayGmv;
+
+  /**
+   * 成交客单价（单位：分)
+   */
+  @JsonProperty("pay_gmv_per_uv")
+  private String payGmvPerUv;
+
+  /**
+   * 实际结算金额（单位：分）
+   */
+  @JsonProperty("actual_commission")
+  private String actualCommission;
+
+  /**
+   * 预估佣金金额（单位：分）
+   */
+  @JsonProperty("predict_commission")
+  private String predictCommission;
+
+  /**
+   * 商品点击人数
+   */
+  @JsonProperty("product_click_uv")
+  private String productClickUv;
+
+  /**
+   * 商品点击次数
+   */
+  @JsonProperty("product_click_cnt")
+  private String productClickCnt;
+
+  /**
+   * 成交退款金额
+   */
+  @JsonProperty("pay_refund_gmv")
+  private String payRefundGmv;
+
+  /**
+   * 成交退款人数
+   */
+  @JsonProperty("pay_refund_uv")
+  private String payRefundUv;
+
+  /**
+   * 成交退款率
+   */
+  @JsonProperty("pay_refund_ratio")
+  private Double payRefundRatio;
+
+  /**
+   * 发货后成交退款率
+   */
+  @JsonProperty("pay_refund_after_send_ratio")
+  private Double payRefundAfterSendRatio;
+
+  /**
+   * 成交退款订单数
+   */
+  @JsonProperty("pay_refund_cnt")
+  private String payRefundCnt;
+
+  /**
+   * 成交退款件数
+   */
+  @JsonProperty("pay_refund_product_cnt")
+  private String payRefundProductCnt;
+
+  /**
+   * 发货前成交退款率
+   */
+  @JsonProperty("pay_refund_before_send_ratio")
+  private Double payRefundBeforeSendRatio;
+
+  /**
+   * 退款金额（单位：分）
+   */
+  @JsonProperty("refund_gmv")
+  private String refundGmv;
+
+  /**
+   * 退款件数
+   */
+  @JsonProperty("refund_product_cnt")
+  private String refundProductCnt;
+
+  /**
+   * 退款订单数
+   */
+  @JsonProperty("refund_cnt")
+  private String refundCnt;
+
+  /**
+   * 退款人数
+   */
+  @JsonProperty("refund_uv")
+  private String refundUv;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductDataParam.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductDataParam.java
@@ -1,0 +1,33 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * 获取带货商品数据请求参数
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProductDataParam extends CompassFinderBaseParam {
+
+  private static final long serialVersionUID = - 5016298274452168329L;
+
+  /**
+   * 商品id
+   */
+  @JsonProperty("product_id")
+  private String productId;
+
+  public ProductDataParam(String ds, String productId) {
+    super(ds);
+    this.productId = productId;
+  }
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductDataResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductDataResponse.java
@@ -1,0 +1,27 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+/**
+ * 获取带货商品数据响应
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ProductDataResponse extends WxChannelBaseResponse {
+
+  private static final long serialVersionUID = 7264776818163943719L;
+
+  /**
+   * 带货商品数据
+   */
+  @JsonProperty("product_info")
+  private ProductInfo productInfo;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductInfo.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductInfo.java
@@ -1,0 +1,68 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 带货商品数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class ProductInfo implements Serializable {
+
+  private static final long serialVersionUID = - 3347940276601700091L;
+
+  /**
+   * 商品id
+   */
+  @JsonProperty("product_id")
+  private String productId;
+
+  /**
+   * 商品头图
+   */
+  @JsonProperty("head_img_url")
+  private String headImgUrl;
+
+  /**
+   * 商品标题
+   */
+  @JsonProperty("title")
+  private String title;
+
+  /**
+   * 商品价格
+   */
+  @JsonProperty("price")
+  private String price;
+
+  /**
+   * 1级类目
+   */
+  @JsonProperty("first_category_id")
+  private String firstCategoryId;
+
+  /**
+   * 2级类目
+   */
+  @JsonProperty("second_category_id")
+  private String secondCategoryId;
+
+  /**
+   * 3级类目
+   */
+  @JsonProperty("third_category_id")
+  private String thirdCategoryId;
+
+  /**
+   * 商品罗盘数据
+   */
+  @JsonProperty("data")
+  private ProductCompassData data;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductListResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/ProductListResponse.java
@@ -1,0 +1,29 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 获取带货商品列表响应
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ProductListResponse extends WxChannelBaseResponse {
+
+  private static final long serialVersionUID = 7903039293558611066L;
+
+  /**
+   * 带货商品列表
+   */
+  @JsonProperty("product_list")
+  private List<ProductInfo> productList;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/SaleProfileData.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/SaleProfileData.java
@@ -1,0 +1,27 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 带货人群数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class SaleProfileData implements Serializable {
+
+  private static final long serialVersionUID = - 5542602540358792014L;
+
+  /**
+   * 维度数据列表
+   */
+  @JsonProperty("field_list")
+  private List<Field> fieldList;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/SaleProfileDataParam.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/SaleProfileDataParam.java
@@ -1,0 +1,33 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * 获取带货人群数据请求参数
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SaleProfileDataParam extends CompassFinderBaseParam {
+
+  private static final long serialVersionUID = 4037843292285732855L;
+
+  /**
+   * 用户类型 {@link me.chanjar.weixin.channel.enums.SaleProfileUserType}
+   */
+  @JsonProperty("type")
+  private Integer type;
+
+  public SaleProfileDataParam(String ds, Integer type) {
+    super(ds);
+    this.type = type;
+  }
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/SaleProfileDataResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/compass/finder/SaleProfileDataResponse.java
@@ -1,0 +1,27 @@
+package me.chanjar.weixin.channel.bean.compass.finder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+/**
+ * 获取带货人群数据响应
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class SaleProfileDataResponse extends WxChannelBaseResponse {
+
+  private static final long serialVersionUID = - 6409722880191468272L;
+
+  /**
+   * 带货人群数据
+   */
+  @JsonProperty("data")
+  private SaleProfileData data;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/ConversionMetric.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/ConversionMetric.java
@@ -1,0 +1,61 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 转化率
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class ConversionMetric implements Serializable {
+
+  private static final long serialVersionUID = - 3411290344181494863L;
+
+  /**
+   * 商品曝光-点击转化率
+   */
+  @JsonProperty("product_view_click_conversion_ratio")
+  private ItemConversionMetric productViewClickConversionRatio;
+
+  /**
+   * 气泡曝光-点击转化率
+   */
+  @JsonProperty("bubble_view_click_conversion_ratio")
+  private ItemConversionMetric bubbleViewClickConversionRatio;
+
+  /**
+   * 成交转化率
+   */
+  @JsonProperty("pay_conversion_ratio")
+  private ItemConversionMetric payConversionRatio;
+
+  /**
+   * 千次观看成交金额（单位：分）
+   */
+  @JsonProperty("k_view_pay_conversion_ratio")
+  private ItemConversionMetric kViewPayConversionRatio;
+
+  /**
+   * 更新时间
+   */
+  @JsonProperty("update_time")
+  private Long updateTime;
+
+  /**
+   * 购物袋商品点击率
+   */
+  @JsonProperty("product_list_click_conversion_ratio")
+  private ItemConversionMetric productListClickConversionRatio;
+
+  /**
+   * 挂车时间（>0 则为挂车）
+   */
+  @JsonProperty("shelftime")
+  private Long shelftime;
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/DataNode.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/DataNode.java
@@ -1,0 +1,26 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 统计数值
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class DataNode implements Serializable {
+
+  private static final long serialVersionUID = 3192158546911682577L;
+
+  /**
+   * 统计数值维度指标
+   */
+  @JsonProperty("fields")
+  private Fields fields;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/DataNodeList.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/DataNodeList.java
@@ -1,0 +1,32 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 分类下的数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class DataNodeList implements Serializable {
+
+  private static final long serialVersionUID = - 497502210938812386L;
+
+  /**
+   * 细分类别的名称，如 "女"、"30-39岁"、"天津市"
+   */
+  @JsonProperty("key")
+  private String key;
+
+  /**
+   * 包含具体的统计数值
+   */
+  @JsonProperty("row")
+  private DataNode row;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/DataNodeSecondList.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/DataNodeSecondList.java
@@ -1,0 +1,33 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 用户群体下不同分类的统计数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class DataNodeSecondList implements Serializable {
+
+  private static final long serialVersionUID = 42973481125049275L;
+
+  /**
+   * 每个分类对象都有一个 key，表示分类的名称，例如 "sex_distribution"、"age_distribution" {@link me.chanjar.weixin.channel.enums.EcProfileDataNodeKey}
+   */
+  @JsonProperty("key")
+  private String key;
+
+  /**
+   * 进一步细分该分类下的数据
+   */
+  @JsonProperty("row")
+  private List<DataNodeList> row;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/DataNodeThirdList.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/DataNodeThirdList.java
@@ -1,0 +1,33 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 不同用户群体的统计数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class DataNodeThirdList implements Serializable {
+
+  private static final long serialVersionUID = - 7534433586440870881L;
+
+  /**
+   * 每个对象包含一个 key，表示用户群体的名称，例如 "已成交用户"、"首次购买用户"、"复购用户"
+   */
+  @JsonProperty("key")
+  private String key;
+
+  /**
+   * 包含该用户群体下不同分类的统计数据
+   */
+  @JsonProperty("row")
+  private List<DataNodeSecondList> row;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Dimension.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Dimension.java
@@ -1,0 +1,38 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 描述时间序列的维度标签
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class Dimension implements Serializable {
+
+  private static final long serialVersionUID = - 1879006149576217182L;
+
+  /**
+   * 维度的类型 {@link me.chanjar.weixin.channel.enums.DimensionType}
+   */
+  @JsonProperty("type")
+  private Integer type;
+
+  /**
+   * 维度标签
+   */
+  @JsonProperty("ux_label")
+  private String uxLabel;
+
+  /**
+   * 维度值
+   */
+  @JsonProperty("dimension_value")
+  private Long dimensionValue;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Ended.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Ended.java
@@ -1,0 +1,44 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 关播内容力数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class Ended implements Serializable {
+
+  private static final long serialVersionUID = 576815272236922652L;
+
+  /**
+   * 曝光有效CTR（万分比）
+   */
+  @JsonProperty("recommend_effective_new_watch_2_uv_over_impression_uv")
+  private EndedIndexItem recommendEffectiveNewWatch2UvOverImpressionUv;
+
+  /**
+   * 人均看播时长
+   */
+  @JsonProperty("average_watch_seconds")
+  private EndedIndexItem averageWatchSeconds;
+
+  /**
+   * 评论率（万分比）
+   */
+  @JsonProperty("comment_uv_over_new_watch_uv")
+  private EndedIndexItem commentUvOverNewWatchUv;
+
+  /**
+   * 点赞率（万分比）
+   */
+  @JsonProperty("like_uv_over_new_watch_uv")
+  private EndedIndexItem likeUvOverNewWatchUv;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/EndedIndexItem.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/EndedIndexItem.java
@@ -1,0 +1,38 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 关播内容力指标数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class EndedIndexItem implements Serializable {
+
+  private static final long serialVersionUID = 7529336638744298238L;
+
+  /**
+   * 整场直播的指标值
+   */
+  @JsonProperty("value")
+  private Long value;
+
+  /**
+   * 整场直播该指标值打败了 xx% 的主播
+   */
+  @JsonProperty("percentile")
+  private Integer percentile;
+
+  /**
+   * 该指标 7 天中位数
+   */
+  @JsonProperty("median_7_days")
+  private Long median7Days;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Fields.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Fields.java
@@ -1,0 +1,38 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 统计数值维度指标数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class Fields implements Serializable {
+
+  private static final long serialVersionUID = 228387216076265877L;
+
+  /**
+   * 维度值
+   */
+  @JsonProperty("dim_key")
+  private String dimKey;
+
+  /**
+   * 指标值
+   */
+  @JsonProperty("dim_val")
+  private String dimVal;
+
+  /**
+   * 指标值比例
+   */
+  @JsonProperty("dim_val_ratio")
+  private String dimValRatio;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/ItemConversionMetric.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/ItemConversionMetric.java
@@ -1,0 +1,44 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 转化率数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class ItemConversionMetric implements Serializable {
+
+  private static final long serialVersionUID = - 8317027740221390754L;
+
+  /**
+   * 指标值
+   */
+  @JsonProperty("metric_value")
+  private Double metricValue;
+
+  /**
+   * 较近7天中位数
+   */
+  @JsonProperty("median_to_recent_7_days")
+  private Double medianToRecent7Days;
+
+  /**
+   * 同行对比
+   */
+  @JsonProperty("within_industry_percentage")
+  private Double withinIndustryPercentage;
+
+  /**
+   * 环比数据
+   */
+  @JsonProperty("quarterly_growth_rate")
+  private QuarterlyGrowthRate quarterlyGrowthRate;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveComparisonIndex.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveComparisonIndex.java
@@ -1,0 +1,38 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 内容力数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveComparisonIndex implements Serializable {
+
+  private static final long serialVersionUID = 525214144965479881L;
+
+  /**
+   * 是否正在直播
+   */
+  @JsonProperty("is_living")
+  private Boolean isLiving;
+
+  /**
+   * 在播数据
+   */
+  @JsonProperty("on_air")
+  private OnAir onAir;
+
+  /**
+   * 关播数据
+   */
+  @JsonProperty("ended")
+  private Ended ended;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData.java
@@ -1,0 +1,38 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 直播大屏数据
+ *
+ * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDashboardData implements Serializable {
+
+  private static final long serialVersionUID = 7917049411269553153L;
+
+  /**
+   * 直播大屏数据实体
+   */
+  @JsonProperty("live_dashboard_data")
+  private LiveDashboardData2 liveDashboardData;
+
+  /**
+   * 直播时长
+   */
+  @JsonProperty("live_duration")
+  private Long liveDuration;
+
+  /**
+   * 直播开始时间
+   */
+  @JsonProperty("start_time")
+  private Long startTime;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 /**
  * 直播大屏数据
  *
- * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
  */
 @Data
 @NoArgsConstructor

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2.java
@@ -1,0 +1,38 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 直播大屏实体
+ *
+ * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDashboardData2 implements Serializable {
+
+  private static final long serialVersionUID = 3657714024563123097L;
+
+  /**
+   * 直播基础数据
+   */
+  @JsonProperty("summary")
+  private LiveDashboardData2Summary summary;
+
+  /**
+   * 直播流量渠道
+   */
+  @JsonProperty("source")
+  private LiveDashboardData2Source source;
+
+  /**
+   * 直播观众画像
+   */
+  @JsonProperty("portrait")
+  private LiveDashboardData2Portrait portrait;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 /**
  * 直播大屏实体
  *
- * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
  */
 @Data
 @NoArgsConstructor

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Portrait.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Portrait.java
@@ -1,0 +1,33 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 直播观众画像
+ *
+ * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDashboardData2Portrait implements Serializable {
+
+  private static final long serialVersionUID = - 5603781471063785276L;
+
+  /**
+   * 在线人数的画像
+   */
+  @JsonProperty("online_watch_uv")
+  private List<Series> onlineWatchUv;
+
+  /**
+   * 观看人数的画像
+   */
+  @JsonProperty("new_watch_uv")
+  private List<Series> newWatchUv;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Portrait.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Portrait.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * 直播观众画像
  *
- * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
  */
 @Data
 @NoArgsConstructor

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Source.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Source.java
@@ -1,0 +1,27 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 直播流量渠道
+ *
+ * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDashboardData2Source implements Serializable {
+
+  private static final long serialVersionUID = 7347276250944913612L;
+
+  /**
+   * 观看人数的渠道分布
+   */
+  @JsonProperty("new_watch_uv")
+  private List<Series> newWatchUv;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Source.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Source.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * 直播流量渠道
  *
- * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
  */
 @Data
 @NoArgsConstructor

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Summary.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Summary.java
@@ -1,0 +1,80 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 直播基础数据
+ *
+ * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDashboardData2Summary implements Serializable {
+
+  private static final long serialVersionUID = - 9029702302333930066L;
+
+  /**
+   * 观看人数
+   */
+  @JsonProperty("new_watch_uv")
+  private Long newWatchUv;
+
+  /**
+   * 最大在线人数
+   */
+  @JsonProperty("max_online_watch_uv")
+  private Long maxOnlineWatchUv;
+
+  /**
+   * 曝光人数
+   */
+  @JsonProperty("impression_uv")
+  private Long impressionUv;
+
+  /**
+   * 平均观看时长（秒）
+   */
+  @JsonProperty("average_watch_seconds_per_audience")
+  private Long averageWatchSecondsPerAudience;
+
+  /**
+   * 新增关注人数
+   */
+  @JsonProperty("new_follow_uv")
+  private Long newFollowUv;
+
+  /**
+   * 新增粉丝团人数
+   */
+  @JsonProperty("new_fans_club_uv")
+  private Long newFansClubUv;
+
+  /**
+   * 评论人数
+   */
+  @JsonProperty("comment_uv")
+  private Long commentUv;
+
+  /**
+   * 打赏人数
+   */
+  @JsonProperty("reward_uv")
+  private Long rewardUv;
+
+  /**
+   * 分享直播间人数
+   */
+  @JsonProperty("sharing_uv")
+  private Long sharingUv;
+
+  /**
+   * 热度
+   */
+  @JsonProperty("hot_quota")
+  private Long hotQuota;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Summary.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDashboardData2Summary.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 /**
  * 直播基础数据
  *
- * @author @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
  */
 @Data
 @NoArgsConstructor

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDataParam.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDataParam.java
@@ -1,0 +1,30 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 获取直播大屏数据请求参数
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LiveDataParam implements Serializable {
+
+  private static final long serialVersionUID = 6346941931704153857L;
+
+  /**
+   * 直播唯一ID
+   */
+  @JsonProperty("export_id")
+  private String exportId;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDataResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDataResponse.java
@@ -1,0 +1,69 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+/**
+ * 获取直播大屏数据响应
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class LiveDataResponse extends WxChannelBaseResponse {
+
+  private static final long serialVersionUID = - 8416743234527598719L;
+
+  /**
+   * 追踪ID，报bug带
+   */
+  @JsonProperty("trace_id")
+  private String traceId;
+
+  /**
+   * 直播大屏基础数据
+   */
+  @JsonProperty("live_dashboard_data")
+  private LiveDashboardData liveDashboardData;
+
+  /**
+   * 内容力数据
+   */
+  @JsonProperty("live_comparison_index")
+  private LiveComparisonIndex liveComparisonIndex;
+
+  /**
+   * 电商数据概要数据
+   */
+  @JsonProperty("live_ec_data_summary")
+  private LiveEcDataSummary liveEcDataSummary;
+
+  /**
+   * 电商转化力数据
+   */
+  @JsonProperty("live_ec_conversion_metric")
+  private LiveEcConversionMetric liveEcConversionMetric;
+
+  /**
+   * 电商画像数据
+   */
+  @JsonProperty("live_ec_profile")
+  private LiveEcProfile liveEcProfile;
+
+  /**
+   * 电商渠道分布
+   */
+  @JsonProperty("live_distribution_channel")
+  private LiveDistributionChannel liveDistributionChannel;
+
+  /**
+   * 电商商品数据
+   */
+  @JsonProperty("single_live_ec_spu_data_page_v2")
+  private SingleLiveEcSpuDataPageV2 singleLiveEcSpuDataPageV2;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDistChannelSourceStats.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDistChannelSourceStats.java
@@ -1,0 +1,81 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 流量来源渠道指标数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDistChannelSourceStats implements Serializable {
+
+  private static final long serialVersionUID = - 6802106934852140579L;
+
+  /**
+   * 渠道层级
+   */
+  @JsonProperty("level")
+  private Integer level;
+
+  /**
+   * 来源渠道ID
+   */
+  @JsonProperty("source_channel_id")
+  private Long sourceChannelId;
+
+  /**
+   * 流量来源子渠道指标数据统计值
+   */
+  @JsonProperty("sub_channel_source_stats")
+  private List<SubLiveDistChannelSourceStats> subChannelSourceStats;
+
+  /**
+   * GMV总值（单位：分）
+   */
+  @JsonProperty("gmv")
+  private Long gmv;
+
+  /**
+   * UV总值
+   */
+  @JsonProperty("uv")
+  private Long uv;
+
+  /**
+   * 千次看播成交（单位： 分）(GPV)
+   */
+  @JsonProperty("gmv_per_uv")
+  private Long gmvPerUv;
+
+  /**
+   * gmv占比
+   */
+  @JsonProperty("gmv_ratio")
+  private Double gmvRatio;
+
+  /**
+   * uv占比
+   */
+  @JsonProperty("uv_ratio")
+  private Double uvRatio;
+
+  /**
+   * 渠道名称
+   */
+  @JsonProperty("source_channel_name")
+  private String sourceChannelName;
+
+  /**
+   * 当前层级pv占总pv的比例
+   */
+  @JsonProperty("pv_ratio")
+  private Double pvRatio;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDistributionByFlowTypeStat.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDistributionByFlowTypeStat.java
@@ -1,0 +1,81 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 流量类型、渠道层级的渠道分析统计数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDistributionByFlowTypeStat implements Serializable {
+
+  private static final long serialVersionUID = 5885014384803438677L;
+
+  /**
+   * 渠道流量类型 {@link me.chanjar.weixin.channel.enums.LiveDistributionFlowType}
+   */
+  @JsonProperty("live_dst_channel_type")
+  private Integer liveDstChannelType;
+
+  /**
+   * 一级类目渠道来源指标划分
+   */
+  @JsonProperty("channel_source_stats")
+  private List<LiveDistChannelSourceStats> channelSourceStats;
+
+  /**
+   * 在该渠道下的统计值
+   */
+  @JsonProperty("metric_value")
+  private Long metricValue;
+
+  /**
+   * GMV总值（单位：分）
+   */
+  @JsonProperty("gmv")
+  private Long gmv;
+
+  /**
+   * UV总值
+   */
+  @JsonProperty("uv")
+  private Long uv;
+
+  /**
+   * 千次看播成交（单位： 分）(GPV)
+   */
+  @JsonProperty("gmv_per_uv")
+  private Long gmvPerUv;
+
+  /**
+   * PV总值
+   */
+  @JsonProperty("pv")
+  private Long pv;
+
+  /**
+   * 当前层级pv占总pv的比例
+   */
+  @JsonProperty("pv_ratio")
+  private Double pvRatio;
+
+  /**
+   * uv占比
+   */
+  @JsonProperty("uv_ratio")
+  private Double uvRatio;
+
+  /**
+   * 在该渠道下的统计值比率
+   */
+  @JsonProperty("metric_value_ratio")
+  private Double metricValueRatio;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDistributionChannel.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDistributionChannel.java
@@ -1,0 +1,51 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 电商渠道分布
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDistributionChannel implements Serializable {
+
+  private static final long serialVersionUID = - 5898886208775573377L;
+
+  /**
+   * 客户数
+   */
+  @JsonProperty("audience_count")
+  private Long audienceCount;
+
+  /**
+   * 总进入直播数
+   */
+  @JsonProperty("total_joinlive_count")
+  private Long totalJoinliveCount;
+
+  /**
+   * 按场景划分的渠道分析统计值
+   */
+  @JsonProperty("live_dist_channel_source_by_scene_stats")
+  private List<LiveDistributionSceneStat> liveDistChannelSourceBySceneStats;
+
+  /**
+   * 按照流量类型、渠道层级划分的渠道分析统计数据
+   */
+  @JsonProperty("live_dist_channel_source_stats")
+  private List<LiveDistributionByFlowTypeStat> liveDistChannelSourceStats;
+
+  /**
+   * 数据版本（无实际意义）
+   */
+  @JsonProperty("data_key")
+  private List<String> dataKey;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDistributionSceneStat.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveDistributionSceneStat.java
@@ -1,0 +1,75 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 场景的渠道分析统计值
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveDistributionSceneStat implements Serializable {
+
+  private static final long serialVersionUID = 4261140121141859416L;
+
+  /**
+   * 场景类型 {@link me.chanjar.weixin.channel.enums.LiveDistributionSceneType}
+   */
+  @JsonProperty("scene_type")
+  private Integer sceneType;
+
+  /**
+   * 该场景下的渠道分析统计值
+   */
+  @JsonProperty("dist_flow_type_stats")
+  private List<LiveDistributionByFlowTypeStat> distFlowTypeStats;
+
+  /**
+   * 指标值总数
+   */
+  @JsonProperty("metric_value_total")
+  private Long metricValueTotal;
+
+  /**
+   * GMV总值（单位：分）
+   */
+  @JsonProperty("gmv")
+  private Long gmv;
+
+  /**
+   * UV总值
+   */
+  @JsonProperty("uv")
+  private Long uv;
+
+  /**
+   * 千次看播成交（单位： 分）
+   */
+  @JsonProperty("gmv_per_uv")
+  private Long gmvPerUv;
+
+  /**
+   * 指标值
+   */
+  @JsonProperty("metric_value")
+  private Long metricValue;
+
+  /**
+   * 在该渠道下的统计值比率
+   */
+  @JsonProperty("metric_value_ratio")
+  private Double metricValueRatio;
+
+  /**
+   * pv
+   */
+  @JsonProperty("pv")
+  private Long pv;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveEcConversionMetric.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveEcConversionMetric.java
@@ -1,0 +1,32 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 电商转化力数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveEcConversionMetric implements Serializable {
+
+  private static final long serialVersionUID = - 7332281175637902883L;
+
+  /**
+   * 近10分钟转化率数据
+   */
+  @JsonProperty("recent_10_min_conversion")
+  private ConversionMetric recent10MinConversion;
+
+  /**
+   * 整场直播
+   */
+  @JsonProperty("whole_live_conversion")
+  private ConversionMetric wholeLiveConversion;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveEcDataSummary.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveEcDataSummary.java
@@ -1,0 +1,212 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 电商数据概要数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveEcDataSummary implements Serializable {
+
+  private static final long serialVersionUID = - 6634047980552575196L;
+
+  /**
+   * 成交金额（单位：分）
+   */
+  @JsonProperty("total_gmv")
+  private Long totalGmv;
+
+  /**
+   * 成交次数
+   */
+  @JsonProperty("total_pay_pv")
+  private Long totalPayPv;
+
+  /**
+   * 成交人数
+   */
+  @JsonProperty("total_pay_uv")
+  private Long totalPayUv;
+
+  /**
+   * 订单创建次数
+   */
+  @JsonProperty("total_create_pv")
+  private Long totalCreatePv;
+
+  /**
+   * 订单创建人数
+   */
+  @JsonProperty("total_create_uv")
+  private Long totalCreateUv;
+
+  /**
+   * 总点击次数
+   */
+  @JsonProperty("total_clk_pv")
+  private Long totalClkPv;
+
+  /**
+   * 总点击人数
+   */
+  @JsonProperty("total_clk_uv")
+  private Long totalClkUv;
+
+  /**
+   * 总曝光次数
+   */
+  @JsonProperty("total_exp_pv")
+  private Long totalExpPv;
+
+  /**
+   * 总曝光人数
+   */
+  @JsonProperty("total_exp_uv")
+  private Long totalExpUv;
+
+  /**
+   * 在线观众数
+   */
+  @JsonProperty("online_audience_count")
+  private Long onlineAudienceCount;
+
+  /**
+   * 累计观众数
+   */
+  @JsonProperty("cumulative_audience_count")
+  private Long cumulativeAudienceCount;
+
+  /**
+   * 新增观众数
+   */
+  @JsonProperty("new_audience_count")
+  private Long newAudienceCount;
+
+  /**
+   * 剩余观众数
+   */
+  @JsonProperty("leaved_audience_count")
+  private Long leavedAudienceCount;
+
+  /**
+   * 观众平均观看秒数
+   */
+  @JsonProperty("average_watch_seconds_per_audience")
+  private Long averageWatchSecondsPerAudience;
+
+  /**
+   * 新增关注数
+   */
+  @JsonProperty("new_follow_count")
+  private Long newFollowCount;
+
+  /**
+   * 新增评论数
+   */
+  @JsonProperty("new_comment_count")
+  private Long newCommentCount;
+
+  /**
+   * 分享直播观众数
+   */
+  @JsonProperty("share_live_audience_count")
+  private Long shareLiveAudienceCount;
+
+  /**
+   * 新粉丝俱乐部数
+   */
+  @JsonProperty("new_fans_club_count")
+  private Long newFansClubCount;
+
+  /**
+   * 退费次数
+   */
+  @JsonProperty("refund_pv")
+  private Long refundPv;
+
+  /**
+   * 退费人数
+   */
+  @JsonProperty("refund_uv")
+  private Long refundUv;
+
+  /**
+   * 退费率
+   */
+  @JsonProperty("refund_rate")
+  private Double refundRate;
+
+  /**
+   * 退款金额（单位：分）
+   */
+  @JsonProperty("refund_amount")
+  private Long refundAmount;
+
+  /**
+   * 退费商品件数
+   */
+  @JsonProperty("refund_product_cnt")
+  private Long refundProductCnt;
+
+  /**
+   * 广告累计观众数
+   */
+  @JsonProperty("ads_cumulative_audience_count")
+  private Long adsCumulativeAudienceCount;
+
+  /**
+   * 广告累计观看数
+   */
+  @JsonProperty("ads_cumulative_watch_count")
+  private Long adsCumulativeWatchCount;
+
+  /**
+   * 促销累计观看数
+   */
+  @JsonProperty("promotion_cumulative_watch_count")
+  private Long promotionCumulativeWatchCount;
+
+  /**
+   * 千次看播成交总额
+   */
+  @JsonProperty("gmv_per_thousand_cumulative_watch_pv")
+  private Double gmvPerThousandCumulativeWatchPv;
+
+  /**
+   * 观众成交率
+   */
+  @JsonProperty("audience_pay_ratio")
+  private Double audiencePayRatio;
+
+  /**
+   * 点击成交率
+   */
+  @JsonProperty("clk_pay_ratio")
+  private Double clkPayRatio;
+
+  /**
+   * 新买家人数
+   */
+  @JsonProperty("new_buyer_uv")
+  private Long newBuyerUv;
+
+  /**
+   * 老买家人数
+   */
+  @JsonProperty("old_buyer_uv")
+  private Long oldBuyerUv;
+
+  /**
+   * 客户价格
+   */
+  @JsonProperty("customer_price")
+  private Long customerPrice;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveEcProfile.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveEcProfile.java
@@ -1,0 +1,33 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 电商画像数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveEcProfile implements Serializable {
+
+  private static final long serialVersionUID = 1996741772652344438L;
+
+  /**
+   * 包含不同用户群体的统计数据
+   */
+  @JsonProperty("profiles")
+  private List<DataNodeThirdList> profiles;
+
+  /**
+   * 总体数据统计信息
+   */
+  @JsonProperty("totals")
+  private List<DataNodeList> totals;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveItem.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveItem.java
@@ -1,0 +1,32 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 直播列表数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class LiveItem implements Serializable {
+
+  private static final long serialVersionUID = 6693176992531666035L;
+
+  /**
+   * 直播唯一ID
+   */
+  @JsonProperty("export_id")
+  private String exportId;
+
+  /**
+   * 直播创建时间
+   */
+  @JsonProperty("create_time")
+  private Long createTime;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveListParam.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveListParam.java
@@ -1,0 +1,30 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 获取直播大屏直播列表请求参数
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LiveListParam implements Serializable {
+
+  private static final long serialVersionUID = - 8451283214646387030L;
+
+  /**
+   * 日期，格式 yyyyMMdd
+   */
+  @JsonProperty("ds")
+  private Long ds;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveListResponse.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/LiveListResponse.java
@@ -1,0 +1,41 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.channel.bean.base.WxChannelBaseResponse;
+
+import java.util.List;
+
+/**
+ * 获取直播大屏直播列表响应
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class LiveListResponse extends WxChannelBaseResponse {
+
+  private static final long serialVersionUID = - 5062337147636715367L;
+
+  /**
+   * 追踪ID，报bug带
+   */
+  @JsonProperty("trace_id")
+  private String traceId;
+
+  /**
+   * 直播列表
+   */
+  @JsonProperty("live_items")
+  private List<LiveItem> liveItems;
+
+  /**
+   * 是否还有更多的直播
+   */
+  @JsonProperty("has_more")
+  private Boolean hasMore;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/OnAir.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/OnAir.java
@@ -1,0 +1,44 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 在播内容力数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class OnAir implements Serializable {
+
+  private static final long serialVersionUID = 6354207471314033499L;
+
+  /**
+   * 曝光有效CTR（万分比）
+   */
+  @JsonProperty("recommend_effective_new_watch_2_uv_over_impression_uv")
+  private OnAirIndexItem recommendEffectiveNewWatch2UvOverImpressionUv;
+
+  /**
+   * 人均看播时长
+   */
+  @JsonProperty("average_watch_seconds")
+  private OnAirIndexItem averageWatchSeconds;
+
+  /**
+   * 评论率（万分比）
+   */
+  @JsonProperty("comment_uv_over_new_watch_uv")
+  private OnAirIndexItem commentUvOverNewWatchUv;
+
+  /**
+   * 点赞率（万分比）
+   */
+  @JsonProperty("like_uv_over_new_watch_uv")
+  private OnAirIndexItem likeUvOverNewWatchUv;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/OnAirIndexItem.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/OnAirIndexItem.java
@@ -1,0 +1,56 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 在播内容力指标数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class OnAirIndexItem implements Serializable {
+
+  private static final long serialVersionUID = - 2988342521964183666L;
+
+  /**
+   * 描述最近多少分钟的指标值
+   */
+  @JsonProperty("n")
+  private Integer n;
+
+  /**
+   * 最近 n 分钟该指标的值
+   */
+  @JsonProperty("last_n_mins_value")
+  private Integer lastNMinsValue;
+
+  /**
+   * 最近 2n 到 n 分钟该指标的值（用于环比）
+   */
+  @JsonProperty("last_2n_to_n_mins_value")
+  private Integer last2nToNMinsValue;
+
+  /**
+   * 最近 n 分钟该指标值打败了 xx% 的在播主播
+   */
+  @JsonProperty("last_n_mins_percentile")
+  private Integer lastNMinsPercentile;
+
+  /**
+   * 整场直播的指标值
+   */
+  @JsonProperty("value")
+  private Long value;
+
+  /**
+   * 整场直播该指标值打败了 xx% 的主播
+   */
+  @JsonProperty("percentile")
+  private Integer percentile;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Point.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Point.java
@@ -1,0 +1,32 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 数据点
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class Point implements Serializable {
+
+  private static final long serialVersionUID = 3332256418933163389L;
+
+  /**
+   * 时间戳
+   */
+  @JsonProperty("ts")
+  private Long ts;
+
+  /**
+   * 指标值
+   */
+  @JsonProperty("value")
+  private Long value;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/QuarterlyGrowthRate.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/QuarterlyGrowthRate.java
@@ -1,0 +1,32 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 转化率环比数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class QuarterlyGrowthRate implements Serializable {
+
+  private static final long serialVersionUID = 1683118806978367016L;
+
+  /**
+   * 环比（近10分钟转化率数据才有）
+   */
+  @JsonProperty("value")
+  private Long value;
+
+  /**
+   * 环比是否是有效值（如果是false说明分母是0）
+   */
+  @JsonProperty("is_valid")
+  private Boolean isValid;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Series.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/Series.java
@@ -1,0 +1,51 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 维度标签的时间序列（与指标的类型无关）
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class Series implements Serializable {
+
+  private static final long serialVersionUID = 507937573085880287L;
+
+  /**
+   * 数据点
+   */
+  @JsonProperty("points")
+  private List<Point> points;
+
+  /**
+   * 描述时间序列的维度标签
+   */
+  @JsonProperty("dimensions")
+  private List<Dimension> dimensions;
+
+  /**
+   * 每个数据点描述的时间长度（秒）
+   */
+  @JsonProperty("step")
+  private Long step;
+
+  /**
+   * 该时间序列的起始时间戳
+   */
+  @JsonProperty("begin_ts")
+  private Long beginTs;
+
+  /**
+   * 该时间序列的结束时间戳
+   */
+  @JsonProperty("end_ts")
+  private Long endTs;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/SingleLiveEcSpuDataPageV2.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/SingleLiveEcSpuDataPageV2.java
@@ -1,0 +1,39 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 电商商品数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class SingleLiveEcSpuDataPageV2 implements Serializable {
+
+  private static final long serialVersionUID = - 761977668198342583L;
+
+  /**
+   * 商品明细数据列表
+   */
+  @JsonProperty("spu_data_list")
+  private List<SpuData> spuDataList;
+
+  /**
+   * spu_data_list 的总长度
+   */
+  @JsonProperty("total_cnt")
+  private Integer totalCnt;
+
+  /**
+   * 数据版本（无实际意义）
+   */
+  @JsonProperty("data_key")
+  private List<String> dataKey;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/SpuBaseData.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/SpuBaseData.java
@@ -1,0 +1,68 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 商品基础数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class SpuBaseData implements Serializable {
+
+  private static final long serialVersionUID = 3170611962212344198L;
+
+  /**
+   * 店铺商品id
+   */
+  @JsonProperty("src_spu_id")
+  private String srcSpuId;
+
+  /**
+   * 店铺id
+   */
+  @JsonProperty("src")
+  private Long src;
+
+  /**
+   * 商品名称
+   */
+  @JsonProperty("spu_name")
+  private String spuName;
+
+  /**
+   * 商品id
+   */
+  @JsonProperty("spu_id")
+  private Long spuId;
+
+  /**
+   * 商品小图
+   */
+  @JsonProperty("thumb_url")
+  private String thumbUrl;
+
+  /**
+   * 商品价格
+   */
+  @JsonProperty("price")
+  private Long price;
+
+  /**
+   * 店铺名称
+   */
+  @JsonProperty("src_name")
+  private String srcName;
+
+  /**
+   * 库存
+   */
+  @JsonProperty("stock")
+  private Long stock;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/SpuData.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/SpuData.java
@@ -1,0 +1,350 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 商品明细数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class SpuData implements Serializable {
+
+  private static final long serialVersionUID = 7409791549917863816L;
+
+  /**
+   * 商品基础数据
+   */
+  @JsonProperty("base_data")
+  private SpuBaseData baseData;
+
+  /**
+   * 商品曝光人数
+   */
+  @JsonProperty("exp_uv")
+  private Long expUv;
+
+  /**
+   * 商品曝光次数
+   */
+  @JsonProperty("exp_pv")
+  private Long expPv;
+
+  /**
+   * 商品粉丝曝光人数
+   */
+  @JsonProperty("fans_exp_uv")
+  private Long fansExpUv;
+
+  /**
+   * 商品粉丝曝光次数
+   */
+  @JsonProperty("fans_exp_pv")
+  private Long fansExpPv;
+
+  /**
+   * 商品非粉丝曝光人数
+   */
+  @JsonProperty("non_fans_exp_uv")
+  private Long nonFansExpUv;
+
+  /**
+   * 商品非粉丝曝光次数
+   */
+  @JsonProperty("non_fans_exp_pv")
+  private Long nonFansExpPv;
+
+  /**
+   * 商品新客户曝光人数
+   */
+  @JsonProperty("new_customer_exp_uv")
+  private Long newCustomerExpUv;
+
+  /**
+   * 商品新客户曝光次数
+   */
+  @JsonProperty("new_customer_exp_pv")
+  private Long newCustomerExpPv;
+
+  /**
+   * 商品老客户曝光人数
+   */
+  @JsonProperty("repeated_customer_exp_uv")
+  private Long repeatedCustomerExpUv;
+
+  /**
+   * 商品老客户曝光次数
+   */
+  @JsonProperty("repeated_customer_exp_pv")
+  private Long repeatedCustomerExpPv;
+
+  /**
+   * 商品点击人数
+   */
+  @JsonProperty("clk_uv")
+  private Long clkUv;
+
+  /**
+   * 商品点击次数
+   */
+  @JsonProperty("clk_pv")
+  private Long clkPv;
+
+  /**
+   * 商品新客户点击人数
+   */
+  @JsonProperty("new_customer_clk_uv")
+  private Long newCustomerClkUv;
+
+  /**
+   * 商品新客户点击次数
+   */
+  @JsonProperty("new_customer_clk_pv")
+  private Long newCustomerClkPv;
+
+  /**
+   * 商品老客户点击人数
+   */
+  @JsonProperty("repeated_customer_clk_uv")
+  private Long repeatedCustomerClkUv;
+
+  /**
+   * 商品老客户点击次数
+   */
+  @JsonProperty("repeated_customer_clk_pv")
+  private Long repeatedCustomerClkPv;
+
+  /**
+   * 商品粉丝点击人数
+   */
+  @JsonProperty("fans_clk_uv")
+  private Long fansClkUv;
+
+  /**
+   * 商品粉丝点击次数
+   */
+  @JsonProperty("fans_clk_pv")
+  private Long fansClkPv;
+
+  /**
+   * 商品非粉丝点击人数
+   */
+  @JsonProperty("non_fans_clk_uv")
+  private Long nonFansClkUv;
+
+  /**
+   * 商品非粉丝点击次数
+   */
+  @JsonProperty("non_fans_clk_pv")
+  private Long nonFansClkPv;
+
+  /**
+   * 商品分享人数
+   */
+  @JsonProperty("share_uv")
+  private Long shareUv;
+
+  /**
+   * 商品分享次数
+   */
+  @JsonProperty("share_pv")
+  private Long sharePv;
+
+  /**
+   * 商品曝光点击率
+   */
+  @JsonProperty("exp_clk_ratio")
+  private Double expClkRatio;
+
+  /**
+   * 商品点击成交率
+   */
+  @JsonProperty("clk_pay_ratio")
+  private Double clkPayRatio;
+
+  /**
+   * 商品成交金额（单位：分）
+   */
+  @JsonProperty("gmv")
+  private Long gmv;
+
+  /**
+   * 商品成交订单数
+   */
+  @JsonProperty("pay_pv")
+  private Long payPv;
+
+  /**
+   * 商品成交人数
+   */
+  @JsonProperty("pay_uv")
+  private Long payUv;
+
+  /**
+   * 商品粉丝成交订单数
+   */
+  @JsonProperty("fans_pay_pv")
+  private Long fansPayPv;
+
+  /**
+   * 商品粉丝成交人数
+   */
+  @JsonProperty("fans_pay_uv")
+  private Long fansPayUv;
+
+  /**
+   * 商品非粉丝成交订单数
+   */
+  @JsonProperty("non_fans_pay_pv")
+  private Long nonFansPayPv;
+
+  /**
+   * 商品非粉丝成交人数
+   */
+  @JsonProperty("non_fans_pay_uv")
+  private Long nonFansPayUv;
+
+  /**
+   * 商品新客户成交次数
+   */
+  @JsonProperty("new_customer_pay_pv")
+  private Long newCustomerPayPv;
+
+  /**
+   * 商品新客户成交人数
+   */
+  @JsonProperty("new_customer_pay_uv")
+  private Long newCustomerPayUv;
+
+  /**
+   * 商品老客户成交次数
+   */
+  @JsonProperty("repeated_customer_pay_pv")
+  private Long repeatedCustomerPayPv;
+
+  /**
+   * 商品老客户成交人数
+   */
+  @JsonProperty("repeated_customer_pay_uv")
+  private Long repeatedCustomerPayUv;
+
+  /**
+   * 商品退款人数
+   */
+  @JsonProperty("refund_uv")
+  private Long refundUv;
+
+  /**
+   * 商品退款订单数
+   */
+  @JsonProperty("refund_pv")
+  private Long refundPv;
+
+  /**
+   * 商品退款金额（单位：分）
+   */
+  @JsonProperty("refund_amount")
+  private Long refundAmount;
+
+  /**
+   * 商品订单创建人数
+   */
+  @JsonProperty("create_uv")
+  private Long createUv;
+
+  /**
+   * 商品订单创建次数
+   */
+  @JsonProperty("create_pv")
+  private Long createPv;
+
+  /**
+   * 商品粉丝订单创建人数
+   */
+  @JsonProperty("fans_create_uv")
+  private Long fansCreateUv;
+
+  /**
+   * 商品粉丝订单创建次数
+   */
+  @JsonProperty("fans_create_pv")
+  private Long fansCreatePv;
+
+  /**
+   * 商品非粉丝订单创建人数
+   */
+  @JsonProperty("non_fans_create_uv")
+  private Long nonFansCreateUv;
+
+  /**
+   * 商品非粉丝订单创建次数
+   */
+  @JsonProperty("non_fans_create_pv")
+  private Long nonFansCreatePv;
+
+  /**
+   * 商品新客户订单创建人数
+   */
+  @JsonProperty("new_customer_create_uv")
+  private Long newCustomerCreateUv;
+
+  /**
+   * 商品新客户订单创建次数
+   */
+  @JsonProperty("new_customer_create_pv")
+  private Long newCustomerCreatePv;
+
+  /**
+   * 商品老客户订单创建人数
+   */
+  @JsonProperty("repeated_customer_create_uv")
+  private Long repeatedCustomerCreateUv;
+
+  /**
+   * 商品老客户订单创建次数
+   */
+  @JsonProperty("repeated_customer_create_pv")
+  private Long repeatedCustomerCreatePv;
+
+  /**
+   * 商品库存
+   */
+  @JsonProperty("stock")
+  private Long stock;
+
+  /**
+   * 商品退费率
+   */
+  @JsonProperty("refund_rate")
+  private Double refundRate;
+
+  /**
+   * 商品完成订单数
+   */
+  @JsonProperty("finish_pv")
+  private Long finishPv;
+
+  /**
+   * 商品未完成订单数
+   */
+  @JsonProperty("no_finish_pv")
+  private Long noFinishPv;
+
+  /**
+   * 商品新客户转换率
+   */
+  @JsonProperty("new_customer_conversion_rate")
+  private Double newCustomerConversionRate;
+
+  /**
+   * 商品讲解数
+   */
+  @JsonProperty("explanation_count")
+  private Long explanationCount;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/SubLiveDistChannelSourceStats.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/bean/live/dashboard/SubLiveDistChannelSourceStats.java
@@ -1,0 +1,92 @@
+package me.chanjar.weixin.channel.bean.live.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * 流量来源子渠道指标数据
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Data
+@NoArgsConstructor
+public class SubLiveDistChannelSourceStats implements Serializable {
+
+  private static final long serialVersionUID = - 5279814435684116105L;
+
+  /**
+   * 渠道层级
+   */
+  @JsonProperty("level")
+  private Integer level;
+
+  /**
+   * 来源渠道ID
+   */
+  @JsonProperty("source_channel_id")
+  private Long sourceChannelId;
+
+  /**
+   * 在该渠道下的统计值
+   */
+  @JsonProperty("metric_value")
+  private Long metricValue;
+
+  /**
+   * GMV总值（单位：分）
+   */
+  @JsonProperty("gmv")
+  private Long gmv;
+
+  /**
+   * UV总值
+   */
+  @JsonProperty("uv")
+  private Long uv;
+
+  /**
+   * 千次看播成交（单位： 分）
+   */
+  @JsonProperty("gmv_per_uv")
+  private Long gmvPerUv;
+
+  /**
+   * gmv占比
+   */
+  @JsonProperty("gmv_ratio")
+  private Double gmvRatio;
+
+  /**
+   * uv占比
+   */
+  @JsonProperty("uv_ratio")
+  private Double uvRatio;
+
+  /**
+   * 在该渠道下的统计值比率
+   */
+  @JsonProperty("metric_value_ratio")
+  private Double metricValueRatio;
+
+  /**
+   * 渠道名称
+   */
+  @JsonProperty("source_channel_name")
+  private String sourceChannelName;
+
+  /**
+   * pv
+   */
+  @JsonProperty("pv")
+  private Long pv;
+
+  /**
+   * 当前层级pv占总pv的比例
+   */
+  @JsonProperty("pv_ratio")
+  private Double pvRatio;
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/constant/WxChannelApiUrlConstants.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/constant/WxChannelApiUrlConstants.java
@@ -428,4 +428,44 @@ public class WxChannelApiUrlConstants {
     /** 更新用户等级 */
     String GRADE_UPDATE_URL = "https://api.weixin.qq.com/channels/ec/vip/user/grade/update";
   }
+
+  /**
+   * 直播大屏数据
+   */
+  public interface LiveDashboard {
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/livedashboard/getlivelist.html">获取直播大屏直播列表</a>
+     */
+    String GET_LIVE_LIST_URL = "https://api.weixin.qq.com/channels/livedashboard/getlivelist";
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/livedashboard/getlivedata.html">获取直播大屏数据</a>
+     */
+    String GET_LIVE_DATA_URL = "https://api.weixin.qq.com/channels/livedashboard/getlivedata";
+  }
+
+  /**
+   * 罗盘达人版API
+   */
+  public interface CompassFinder {
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/compass/finder/getfinderoverall.html">获取电商概览数据</a>
+     */
+    String GET_OVERALL_URL = "https://api.weixin.qq.com/channels/ec/compass/finder/overall/get";
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/compass/finder/getfinderproductdata.html">获取带货商品数据</a>
+     */
+    String GET_PRODUCT_DATA_URL = "https://api.weixin.qq.com/channels/ec/compass/finder/product/data/get";
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/compass/finder/getfinderproductlist.html">获取带货商品列表</a>
+     */
+    String GET_PRODUCT_LIST_URL = "https://api.weixin.qq.com/channels/ec/compass/finder/product/list/get";
+
+    /**
+     * <a href="https://developers.weixin.qq.com/doc/channels/API/compass/finder/getfindersaleprofiledata.html">获取带货人群数据</a>
+     */
+    String GET_SALE_PROFILE_DATA_URL = "https://api.weixin.qq.com/channels/ec/compass/finder/sale/profile/data/get";
+  }
 }

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/DimensionType.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/DimensionType.java
@@ -1,0 +1,80 @@
+package me.chanjar.weixin.channel.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * 视频号助手 直播数据维度类型
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum DimensionType {
+
+  /**
+   * 一级渠道
+   */
+  PRIMARY_CHANNEL(1, "一级渠道"),
+  /**
+   * 年龄段
+   */
+  AGE(2, "年龄段"),
+  /**
+   * 性别
+   */
+  SEX(3, "性别"),
+  /**
+   * 关注关系
+   */
+  FOLLOW(5, "关注关系"),
+  /**
+   * 二级渠道
+   */
+  SECONDARY_CHANNEL(7, "二级渠道"),
+  /**
+   * 策略人群
+   */
+  CATE(9, "策略人群"),
+  /**
+   * 省级行政区
+   */
+  PROVINCE(10, "省级行政区"),
+  /**
+   * 地级行政区
+   */
+  CITY(11, "地级行政区"),
+  /**
+   * 消费者商品类目偏好
+   */
+  ECOM_USER_LEVEL(12, "消费者商品类目偏好"),
+  /**
+   * 客单价区间
+   */
+  GMV_PER_CNT(13, "客单价区间"),
+//  /**
+//   * 关注关系
+//   */
+//  FOLLOW(15, "关注关系"),
+  /**
+   * 流量类型（自然流量、直播加热、广告投流）
+   */
+  FLOW(16, "流量类型（自然流量、直播加热、广告投流）"),
+
+  ;
+
+  private final Integer key;
+  private final String value;
+
+  DimensionType(Integer key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public Integer getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/EcProfileDataNodeKey.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/EcProfileDataNodeKey.java
@@ -1,0 +1,64 @@
+package me.chanjar.weixin.channel.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * 视频号助手 用户群体数据节点键
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum EcProfileDataNodeKey {
+
+  /**
+   * 性别分布
+   */
+  SEX("sex_distribution", "性别分布"),
+  /**
+   * 年龄分布
+   */
+  AGE("age_distribution", "年龄分布"),
+  /**
+   * 省份分布
+   */
+  PROVINCE("province_distribution", "省份分布"),
+  /**
+   * 城市分布
+   */
+  CITY("city_distribution", "城市分布"),
+  /**
+   * 关注关系分布
+   */
+  FOLLOW("follow_distribution", "关注关系分布"),
+  /**
+   * 策略人群分布
+   */
+  CATE("cate_distribution", "策略人群分布"),
+  /**
+   * 商品类目偏好分布
+   */
+  ECOM_USER_LEVEL("ecom_user_level_distribution", "商品类目偏好分布"),
+  /**
+   * 平均客单价分布
+   */
+  GMV_PER_CNT("gmv_per_cnt_distribution", "平均客单价分布"),
+
+  ;
+
+  private final String key;
+  private final String value;
+
+  EcProfileDataNodeKey(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/LiveDistributionFlowType.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/LiveDistributionFlowType.java
@@ -1,0 +1,56 @@
+package me.chanjar.weixin.channel.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * 视频号助手 直播分布流量类型
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum LiveDistributionFlowType {
+
+  /**
+   * 无效值
+   */
+  INVALID(0, "无效值"),
+  /**
+   * 自然流量
+   */
+  NATURAL(1, "自然流量"),
+  /**
+   * 加热流量
+   */
+  PROMOTE(2, "加热流量"),
+  /**
+   * 广告流量
+   */
+  ADS(3, "广告流量"),
+  /**
+   * 公域流量
+   */
+  COMMON_DOMAIN(4, "公域流量"),
+  /**
+   * 私域流量
+   */
+  PRIVATE_DOMAIN(5, "私域流量"),
+
+  ;
+
+  private final Integer key;
+  private final String value;
+
+  LiveDistributionFlowType(Integer key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public Integer getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/LiveDistributionSceneType.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/LiveDistributionSceneType.java
@@ -1,0 +1,52 @@
+package me.chanjar.weixin.channel.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * 视频号助手 直播分布场景类型
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum LiveDistributionSceneType {
+
+  /**
+   * 商品曝光
+   */
+  PRODUCT_IMPRESSION(6, "商品曝光"),
+  /**
+   * 直播间曝光次数
+   */
+  LIVE_ROOM_IMPRESSION_PV(7, "直播间曝光次数"),
+  /**
+   * 商品点击次数
+   */
+  PRODUCT_CLICK_PV(8, "商品点击次数"),
+  /**
+   * 创建订单数按渠道统计
+   */
+  CHANNEL_TOTAL_CREATE_PV(9, "创建订单数按渠道统计"),
+  /**
+   * 成交订单数按渠道统计
+   */
+  CHANNEL_TOTAL_PAY_PV(10, "成交订单数按渠道统计"),
+
+  ;
+
+  private final Integer key;
+  private final String value;
+
+  LiveDistributionSceneType(Integer key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public Integer getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/SaleProfileUserType.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/enums/SaleProfileUserType.java
@@ -1,0 +1,56 @@
+package me.chanjar.weixin.channel.enums;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * 带货人群用户类型
+ *
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum SaleProfileUserType {
+
+  /**
+   * 商品曝光用户
+   */
+  PRODUCT_IMPRESSION_USER(1, "商品曝光用户"),
+  /**
+   * 商品点击用户
+   */
+  PRODUCT_CLICK_USER(2, "商品点击用户"),
+  /**
+   * 购买用户
+   */
+  PURCHASING_USER(3, "购买用户"),
+  /**
+   * 首购用户
+   */
+  FIRST_PURCHASE_USER(4, "首购用户"),
+  /**
+   * 复购用户
+   */
+  REPURCHASE_USER(5, "复购用户"),
+  /**
+   * 直播观看用户
+   */
+  LIVE_WATCHER_USER(6, "直播观看用户"),
+
+  ;
+
+  private final Integer key;
+  private final String value;
+
+  SaleProfileUserType(Integer key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public Integer getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+}

--- a/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxChannelCompassFinderServiceImplTest.java
+++ b/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxChannelCompassFinderServiceImplTest.java
@@ -1,0 +1,66 @@
+package me.chanjar.weixin.channel.api.impl;
+
+import com.google.inject.Inject;
+import me.chanjar.weixin.channel.api.WxChannelCompassFinderService;
+import me.chanjar.weixin.channel.api.WxChannelService;
+import me.chanjar.weixin.channel.bean.compass.finder.OverallResponse;
+import me.chanjar.weixin.channel.bean.compass.finder.ProductDataResponse;
+import me.chanjar.weixin.channel.bean.compass.finder.ProductListResponse;
+import me.chanjar.weixin.channel.bean.compass.finder.SaleProfileDataResponse;
+import me.chanjar.weixin.channel.enums.SaleProfileUserType;
+import me.chanjar.weixin.channel.test.ApiTestModule;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Guice(modules = ApiTestModule.class)
+public class WxChannelCompassFinderServiceImplTest {
+
+  @Inject
+  private WxChannelService channelService;
+
+  @Test
+  public void testGetOverAll() throws WxErrorException {
+    WxChannelCompassFinderService compassFinderService = channelService.getCompassFinderService();
+    String ds = "20240630";
+    OverallResponse response = compassFinderService.getOverall(ds);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+  @Test
+  public void testGetProductData() throws WxErrorException {
+    WxChannelCompassFinderService compassFinderService = channelService.getCompassFinderService();
+    String ds = "20240630";
+    String productId = "10000017457793";
+    ProductDataResponse response = compassFinderService.getProductData(ds, productId);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+  @Test
+  public void testGetProductList() throws WxErrorException {
+    WxChannelCompassFinderService compassFinderService = channelService.getCompassFinderService();
+    String ds = "20240630";
+    ProductListResponse response = compassFinderService.getProductList(ds);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+  @Test
+  public void testGetSaleProfileData() throws WxErrorException {
+    WxChannelCompassFinderService compassFinderService = channelService.getCompassFinderService();
+    String ds = "20240630";
+    Integer type = SaleProfileUserType.PRODUCT_IMPRESSION_USER.getKey();
+    SaleProfileDataResponse response = compassFinderService.getSaleProfileData(ds, type);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+}

--- a/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxChannelLiveDashboardServiceImplTest.java
+++ b/weixin-java-channel/src/test/java/me/chanjar/weixin/channel/api/impl/WxChannelLiveDashboardServiceImplTest.java
@@ -1,0 +1,44 @@
+package me.chanjar.weixin.channel.api.impl;
+
+import com.google.inject.Inject;
+import me.chanjar.weixin.channel.api.WxChannelLiveDashboardService;
+import me.chanjar.weixin.channel.api.WxChannelService;
+import me.chanjar.weixin.channel.bean.live.dashboard.LiveDataResponse;
+import me.chanjar.weixin.channel.bean.live.dashboard.LiveListResponse;
+import me.chanjar.weixin.channel.test.ApiTestModule;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author <a href="https://github.com/Winnie-by996">Winnie</a>
+ */
+@Guice(modules = ApiTestModule.class)
+public class WxChannelLiveDashboardServiceImplTest {
+
+  @Inject
+  private WxChannelService channelService;
+
+  @Test
+  public void testGetLiveList() throws WxErrorException {
+    WxChannelLiveDashboardService liveDashboardService = channelService.getLiveDashboardService();
+    // yyyyMMdd
+    Long ds = 20240630L;
+    LiveListResponse response = liveDashboardService.getLiveList(ds);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+  @Test
+  public void testGetLiveData() throws WxErrorException {
+    WxChannelLiveDashboardService liveDashboardService = channelService.getLiveDashboardService();
+    String exportId = "export/UzFf*****************************************************************************************64V";
+    LiveDataResponse response = liveDashboardService.getLiveData(exportId);
+    assertNotNull(response);
+    assertTrue(response.isSuccess());
+  }
+
+}


### PR DESCRIPTION
Feat(新增):
    1. 视频号助手-直播大屏数据、罗盘达人版API接口相关对象实体。
    2. 视频号助手-直播大屏数据、罗盘达人版API接口服务及实现。
    3. 视频号助手-直播大屏数据接口中涉及的类型枚举。
Fix(修改):
    1. 视频号接口地址常量加入直播大屏数据、罗盘达人版API接口地址常量。
    2. 视频号服务中加入直播大屏数据、罗盘达人版API服务获取方法。