### PR TITLE
:art: 初始化v3客户端时，未使用p12证书且未设置证书序列号值才尝试加载证书

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -281,15 +281,13 @@ public class WxPayConfig {
         merchantPrivateKey = PemUtils.loadPrivateKey(keyInputStream);
 
       }
-      if (certificate == null) {
+      if (certificate == null && StringUtils.isBlank(this.getCertSerialNo())) {
         InputStream certInputStream = this.loadConfigInputStream(this.getPrivateCertString(), this.getPrivateCertPath(),
           this.privateCertContent, "privateCertPath");
         certificate = PemUtils.loadCertificate(certInputStream);
-      }
-
-      if (StringUtils.isBlank(this.getCertSerialNo())) {
         this.certSerialNo = certificate.getSerialNumber().toString(16).toUpperCase();
       }
+
       //构造Http Proxy正向代理
       WxPayHttpProxy wxPayHttpProxy = getWxPayHttpProxy();
 


### PR DESCRIPTION
设置了 `certSerialNo` 属性但是没有设置p12证书时会去加载证书导致报错