### PR TITLE
Feature: 小程序切换时支持传递函数，提高扩展性

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaService.java
@@ -2,6 +2,7 @@ package cn.binarywang.wx.miniapp.api;
 
 import cn.binarywang.wx.miniapp.bean.WxMaJscode2SessionResult;
 import cn.binarywang.wx.miniapp.config.WxMaConfig;
+import java.util.function.Function;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.common.service.WxImgProcService;
 import me.chanjar.weixin.common.service.WxOcrService;
@@ -213,12 +214,21 @@ public interface WxMaService extends WxService {
   boolean switchover(String mpId);
 
   /**
-   * 进行相应的公众号切换.
+   * 进行相应的小程序切换.
    *
-   * @param miniappId 小程序标识
+   * @param miniAppId 小程序标识
    * @return 切换成功 ，则返回当前对象，方便链式调用，否则抛出异常
    */
-  WxMaService switchoverTo(String miniappId);
+  WxMaService switchoverTo(String miniAppId);
+
+  /**
+   * 进行相应的小程序切换.
+   *
+   * @param miniAppId 小程序标识
+   * @param func 当对应的小程序配置不存在时，允许通过函数的方式进行调用获取
+   * @return 切换成功 ，则返回当前对象，方便链式调用，否则抛出异常
+   */
+  WxMaService switchoverTo(String miniAppId, Function<String, WxMaConfig> func);
 
   /**
    * 返回消息（客服消息和模版消息）发送接口方法实现类，以方便调用其各个接口.

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/BaseWxMaServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/BaseWxMaServiceImpl.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import me.chanjar.weixin.common.api.WxConsts;
 import me.chanjar.weixin.common.bean.CommonUploadParam;
@@ -431,13 +432,26 @@ public abstract class BaseWxMaServiceImpl<H, P> implements WxMaService, RequestH
   }
 
   @Override
-  public WxMaService switchoverTo(String miniappId) {
-    if (this.configMap.containsKey(miniappId)) {
-      WxMaConfigHolder.set(miniappId);
+  public WxMaService switchoverTo(String miniAppId) {
+    return switchoverTo(miniAppId, null);
+  }
+
+  @Override
+  public WxMaService switchoverTo(String miniAppId, Function<String, WxMaConfig> func) {
+    if (this.configMap.containsKey(miniAppId)) {
+      WxMaConfigHolder.set(miniAppId);
       return this;
     }
 
-    throw new WxRuntimeException(String.format("无法找到对应【%s】的小程序配置信息，请核实！", miniappId));
+    if (func != null) {
+      WxMaConfig config = func.apply(miniAppId);
+      if (config != null) {
+        this.addConfig(miniAppId, config);
+        return this;
+      }
+    }
+
+    throw new WxRuntimeException(String.format("无法找到对应【%s】的小程序配置信息，请核实！", miniAppId));
   }
 
   @Override


### PR DESCRIPTION
当前微信公众号支持切换的时候传递一个Function，在配置不存在的时候通过Function来获取配置，极大的提高了外部使用的灵活性（详见[BaseWxMpServiceImpl.java](https://github.com/Wechat-Group/WxJava/blob/5821710e076a09584bd8af941983c9c6987ec996/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java#L604)），而小程序中不支持传递Function，因此同步增加了该方法，在多小程序的场景下可以灵活使用。