### PR TITLE
fix：【企业微信】修复“审批状态通知事件”企微回调XML序列化为Java对象时approvalNodes和notifyNodes为空的bug

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpXmlApprovalInfo.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpXmlApprovalInfo.java
@@ -91,19 +91,19 @@ public class WxCpXmlApprovalInfo implements Serializable {
   /**
    * 审批流程信息
    */
-  @XStreamImplicit(itemFieldName = "ApprovalNodes")
+  @XStreamAlias("ApprovalNodes")
   private List<ApprovalNode> approvalNodes;
 
   /**
    * 抄送信息，可能有多个抄送人
    */
-  @XStreamImplicit(itemFieldName = "NotifyNodes")
+  @XStreamAlias("NotifyNodes")
   private List<NotifyNode> notifyNodes;
 
   /**
    * 抄送人信息
    */
-  @XStreamAlias("NotifyNodes")
+  @XStreamAlias("NotifyNode")
   @Data
   public static class NotifyNode implements Serializable {
     private static final long serialVersionUID = -979255011922209018L;
@@ -141,7 +141,7 @@ public class WxCpXmlApprovalInfo implements Serializable {
   /**
    * 审批流程信息，可以有多个审批节点
    */
-  @XStreamAlias("ApprovalNodes")
+  @XStreamAlias("ApprovalNode")
   @Data
   public static class ApprovalNode implements Serializable {
     private static final long serialVersionUID = -979255011922209018L;
@@ -167,7 +167,7 @@ public class WxCpXmlApprovalInfo implements Serializable {
     /**
      * 审批节点信息，当节点为标签或上级时，一个节点可能有多个分支
      */
-    @XStreamImplicit(itemFieldName = "Items")
+    @XStreamAlias("Items")
     private List<Item> items;
 
   }
@@ -175,7 +175,7 @@ public class WxCpXmlApprovalInfo implements Serializable {
   /**
    * 审批节点分支，当节点为标签或上级时，一个节点可能有多个分支
    */
-  @XStreamAlias("Items")
+  @XStreamAlias("Item")
   @Data
   public static class Item implements Serializable {
     private static final long serialVersionUID = -979255011922209018L;

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/bean/message/WxCpXmlMessageTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/bean/message/WxCpXmlMessageTest.java
@@ -301,4 +301,84 @@ public class WxCpXmlMessageTest {
 
     System.out.println(XStreamTransformer.toXml(WxCpXmlMessage.class, wxCpXmlMessage));
   }
+
+  /**
+   * Test open approval change.
+   */
+  public void testOpenApprovalChange() {
+    String xml = "<xml>\n" +
+      " <ToUserName><![CDATA[wwddddccc7775555aaa]]></ToUserName>\n" +
+      "  <FromUserName><![CDATA[sys]]></FromUserName>\n" +
+      "  <CreateTime>1527838022</CreateTime>\n" +
+      "  <MsgType><![CDATA[event]]></MsgType>\n" +
+      "  <Event><![CDATA[open_approval_change]]></Event>\n" +
+      "  <AgentID>1</AgentID>\n" +
+      "  <ApprovalInfo>\n" +
+      "    <ThirdNo><![CDATA[201806010001]]></ThirdNo>\n" +
+      "    <OpenSpName><![CDATA[付款]]></OpenSpName>\n" +
+      "    <OpenTemplateId><![CDATA[1234567890]]></OpenTemplateId>\n" +
+      "    <OpenSpStatus>1</OpenSpStatus>\n" +
+      "    <ApplyTime>1527837645</ApplyTime>\n" +
+      "    <ApplyUserName><![CDATA[xiaoming]]></ApplyUserName>\n" +
+      "    <ApplyUserId><![CDATA[1]]></ApplyUserId>\n" +
+      "    <ApplyUserParty><![CDATA[产品部]]></ApplyUserParty>\n" +
+      "    <ApplyUserImage><![CDATA[http://www.qq.com/xxx.png]]></ApplyUserImage>\n" +
+      "    <ApprovalNodes>\n" +
+      "      <ApprovalNode>\n" +
+      "        <NodeStatus>1</NodeStatus>\n" +
+      "        <NodeAttr>1</NodeAttr>\n" +
+      "        <NodeType>1</NodeType>\n" +
+      "        <Items>\n" +
+      "          <Item>\n" +
+      "            <ItemName><![CDATA[xiaohong]]></ItemName>\n" +
+      "            <ItemUserId><![CDATA[2]]></ItemUserId>\n" +
+      "            <ItemImage><![CDATA[http://www.qq.com/xxx.png]]></ItemImage>\n" +
+      "            <ItemStatus>1</ItemStatus>\n" +
+      "            <ItemSpeech><![CDATA[]]></ItemSpeech>\n" +
+      "            <ItemOpTime>0</ItemOpTime>\n" +
+      "          </Item>\n" +
+      "        </Items>\n" +
+      "      </ApprovalNode>\n" +
+      "      <ApprovalNode>\n" +
+      "        <NodeStatus>1</NodeStatus>\n" +
+      "        <NodeAttr>1</NodeAttr>\n" +
+      "        <NodeType>1</NodeType>\n" +
+      "        <Items>\n" +
+      "          <Item>\n" +
+      "            <ItemName><![CDATA[xiaohong]]></ItemName>\n" +
+      "            <ItemUserId><![CDATA[2]]></ItemUserId>\n" +
+      "            <ItemImage><![CDATA[http://www.qq.com/xxx.png]]></ItemImage>\n" +
+      "            <ItemStatus>1</ItemStatus>\n" +
+      "            <ItemSpeech><![CDATA[]]></ItemSpeech>\n" +
+      "            <ItemOpTime>0</ItemOpTime>\n" +
+      "          </Item>\n" +
+      "          <Item>\n" +
+      "            <ItemName><![CDATA[xiaohong]]></ItemName>\n" +
+      "            <ItemUserId><![CDATA[2]]></ItemUserId>\n" +
+      "            <ItemImage><![CDATA[http://www.qq.com/xxx.png]]></ItemImage>\n" +
+      "            <ItemStatus>1</ItemStatus>\n" +
+      "            <ItemSpeech><![CDATA[]]></ItemSpeech>\n" +
+      "            <ItemOpTime>0</ItemOpTime>\n" +
+      "          </Item>\n" +
+      "        </Items>\n" +
+      "      </ApprovalNode>\n" +
+      "    </ApprovalNodes>\n" +
+      "    <NotifyNodes>\n" +
+      "      <NotifyNode>\n" +
+      "        <ItemName><![CDATA[xiaogang]]></ItemName>\n" +
+      "        <ItemUserId><![CDATA[3]]></ItemUserId>\n" +
+      "        <ItemImage><![CDATA[http://www.qq.com/xxx.png]]></ItemImage>\n" +
+      "      </NotifyNode>\n" +
+      "    </NotifyNodes>\n" +
+      "    <approverstep>0</approverstep>\n" +
+      "  </ApprovalInfo>\n" +
+      "</xml>\n";
+
+    WxCpXmlMessage wxCpXmlMessage = WxCpXmlMessage.fromXml(xml);
+    assertThat(wxCpXmlMessage).isNotNull();
+    assertThat(wxCpXmlMessage.getApprovalInfo().getApprovalNodes()).isNotEmpty();
+    assertThat(wxCpXmlMessage.getApprovalInfo().getApprovalNodes().get(0).getItems()).isNotEmpty();
+    assertThat(wxCpXmlMessage.getApprovalInfo().getApprovalNodes().get(0).getItems().get(0).getItemName()).isNotEmpty();
+    assertThat(wxCpXmlMessage.getApprovalInfo().getNotifyNodes().get(0).getItemName()).isNotEmpty();
+  }
 }


### PR DESCRIPTION
fix：【企业微信】修复“审批状态通知事件”企微回调XML序列化为Java对象时approvalNodes和notifyNodes为空的bug，具体可参考提交的测试方法，修改前的测试是不通过的
企微审批状态通知事件文档：https://developer.work.weixin.qq.com/document/path/90240#%E5%AE%A1%E6%89%B9%E7%8A%B6%E6%80%81%E9%80%9A%E7%9F%A5%E4%BA%8B%E4%BB%B6