### PR TITLE
fix：【企业微信】增加"模板卡片事件推送"事件的相关属性

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpXmlMessage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/message/WxCpXmlMessage.java
@@ -187,6 +187,17 @@ public class WxCpXmlMessage implements Serializable {
   @XStreamConverter(value = XStreamCDataConverter.class)
   private String taskId;
 
+  @XStreamAlias("CardType")
+  @XStreamConverter(value = XStreamCDataConverter.class)
+  private String cardType;
+
+  @XStreamAlias("ResponseCode")
+  @XStreamConverter(value = XStreamCDataConverter.class)
+  private String responseCode;
+
+  @XStreamAlias("SelectedItems")
+  private List<SelectedItem> selectedItems;
+
   /**
    * 微信客服
    * 调用拉取消息接口时，需要传此token，用于校验请求的合法性
@@ -735,6 +746,23 @@ public class WxCpXmlMessage implements Serializable {
     @XStreamConverter(value = XStreamCDataConverter.class)
     private String poiName;
 
+  }
+
+
+  /**
+   * The type selected Items.
+   */
+  @Data
+  @XStreamAlias("SelectedItem")
+  public static class SelectedItem implements Serializable {
+    private static final long serialVersionUID = 6319921121637597406L;
+
+    @XStreamAlias("QuestionKey")
+    @XStreamConverter(value = XStreamCDataConverter.class)
+    private String questionKey;
+
+    @XStreamAlias(value = "OptionIds")
+    private List<String> optionIds;
   }
 
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpConsts.java
@@ -49,6 +49,11 @@ public class WxCpConsts {
     public static final String CHANGE_CONTACT = "change_contact";
 
     /**
+     * 企业微信模板卡片事件推送
+     */
+    public static final String TEMPLATE_CARD_EVENT = "template_card_event";
+
+    /**
      * 点击菜单拉取消息的事件推送.
      */
     public static final String CLICK = "click";

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/xml/XStreamTransformer.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/xml/XStreamTransformer.java
@@ -93,6 +93,11 @@ public class XStreamTransformer {
     xstream.processAnnotations(WxCpXmlMessage.SendPicsInfo.class);
     xstream.processAnnotations(WxCpXmlMessage.SendPicsInfo.Item.class);
     xstream.processAnnotations(WxCpXmlMessage.SendLocationInfo.class);
+    xstream.processAnnotations(WxCpXmlMessage.SelectedItem.class);
+    // 显式允许 String 类
+    xstream.allowTypes(new Class[]{String.class});
+    // 模板卡片事件推送独属
+    xstream.alias("OptionId",String.class);
     return xstream;
   }
 

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/bean/message/WxCpXmlMessageTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/bean/message/WxCpXmlMessageTest.java
@@ -301,4 +301,45 @@ public class WxCpXmlMessageTest {
 
     System.out.println(XStreamTransformer.toXml(WxCpXmlMessage.class, wxCpXmlMessage));
   }
+
+
+  /**
+   * Test template card event.
+   */
+  public void testTemplateCardEvent() {
+    String xml = "<xml>\n" +
+      "<ToUserName><![CDATA[toUser]]></ToUserName>\n" +
+      "<FromUserName><![CDATA[FromUser]]></FromUserName>\n" +
+      "<CreateTime>123456789</CreateTime>\n" +
+      "<MsgType><![CDATA[event]]></MsgType>\n" +
+      "<Event><![CDATA[template_card_event]]></Event>\n" +
+      "<EventKey><![CDATA[key111]]></EventKey>\n" +
+      "<TaskId><![CDATA[taskid111]]></TaskId>\n" +
+      "<CardType><![CDATA[text_notice]]></CardType>\n" +
+      "<ResponseCode><![CDATA[ResponseCode]]></ResponseCode>\n" +
+      "<AgentID>1</AgentID>\n" +
+      "<SelectedItems>\n" +
+      "    <SelectedItem>\n" +
+      "        <QuestionKey><![CDATA[QuestionKey1]]></QuestionKey>\n" +
+      "        <OptionIds>\n" +
+      "            <OptionId><![CDATA[OptionId1]]></OptionId>\n" +
+      "            <OptionId><![CDATA[OptionId2]]></OptionId>\n" +
+      "        </OptionIds>\n" +
+      "    </SelectedItem>\n" +
+      "    <SelectedItem>\n" +
+      "        <QuestionKey><![CDATA[QuestionKey2]]></QuestionKey>\n" +
+      "        <OptionIds>\n" +
+      "            <OptionId><![CDATA[OptionId3]]></OptionId>\n" +
+      "            <OptionId><![CDATA[OptionId4]]></OptionId>\n" +
+      "        </OptionIds>\n" +
+      "    </SelectedItem>\n" +
+      "</SelectedItems>\n" +
+      "</xml>";
+
+    WxCpXmlMessage wxCpXmlMessage = WxCpXmlMessage.fromXml(xml);
+    assertThat(wxCpXmlMessage).isNotNull();
+    assertThat(wxCpXmlMessage.getSelectedItems()).isNotEmpty();
+    assertThat(wxCpXmlMessage.getSelectedItems().get(0).getQuestionKey()).isNotEmpty();
+    assertThat(wxCpXmlMessage.getSelectedItems().get(0).getOptionIds().get(0)).isNotEmpty();
+  }
 }


### PR DESCRIPTION
企业微信文档回调事件”模板卡片事件推送“文档：https://developer.work.weixin.qq.com/document/path/90240#%E6%A8%A1%E6%9D%BF%E5%8D%A1%E7%89%87%E4%BA%8B%E4%BB%B6%E6%8E%A8%E9%80%81

【注意】：me.chanjar.weixin.cp.util.xml.XStreamTransformer#configWxCpXmlMessage方法增加了
xstream.allowTypes(new Class[]{String.class});
请留意该行代码是否存在xml序列化为java对象时的安全隐患
![image](https://github.com/user-attachments/assets/f488086f-48af-4bc3-846d-f8257b8a9565)
