### PR TITLE
fix：【企业微信】增加"消息推送-接收消息与事件-事件格式"中的多个事件类型常量

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpConsts.java
@@ -94,6 +94,31 @@ public class WxCpConsts {
     public static final String TASKCARD_CLICK = "taskcard_click";
 
     /**
+     * 企业互联共享应用事件回调.
+     */
+    public static final String SHARE_AGENT_CHANGE = "share_agent_change";
+
+    /**
+     * 上下游共享应用事件回调.
+     */
+    public static final String SHARE_CHAIN_CHANGE = "share_chain_change";
+
+    /**
+     * 通用模板卡片右上角菜单事件推送.
+     */
+    public static final String TEMPLATE_CARD_MENU_EVENT = "template_card_menu_event";
+
+    /**
+     * 长期未使用应用临时停用事件.
+     */
+    public static final String CLOSE_INACTIVE_AGENT = "close_inactive_agent";
+
+    /**
+     * 长期未使用应用重新启用事件.
+     */
+    public static final String REOPEN_INACTIVE_AGENT = "reopen_inactive_agent";
+
+    /**
      * 企业成员添加外部联系人事件推送 & 会话存档客户同意进行聊天内容存档事件回调事件
      */
     public static final String CHANGE_EXTERNAL_CONTACT = "change_external_contact";


### PR DESCRIPTION
这些事件类型常量所在的企业微信文档：https://developer.work.weixin.qq.com/document/path/90240