### PR TITLE
🎨【微信支付】处理微信签名探测流量

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/exception/WxSignTestException.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/exception/WxSignTestException.java
@@ -1,0 +1,31 @@
+package com.github.binarywang.wxpay.exception;
+
+/**
+ * <pre>
+ *   微信支付签名探测异常类
+ * </pre>
+ * @author je45
+ * @date 2024/11/27 9:35
+ */
+public class WxSignTestException extends WxPayException {
+  private static final long serialVersionUID = -303371909244098058L;
+
+  /**
+   * Instantiates a new Wx pay exception.
+   *
+   * @param customErrorMsg the custom error msg
+   */
+  public WxSignTestException(String customErrorMsg) {
+    super(customErrorMsg);
+  }
+
+  /**
+   * Instantiates a new Wx pay exception.
+   *
+   * @param customErrorMsg the custom error msg
+   * @param tr             the tr
+   */
+  public WxSignTestException(String customErrorMsg, Throwable tr) {
+    super(customErrorMsg, tr);
+  }
+}

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
@@ -17,6 +17,7 @@ import com.github.binarywang.wxpay.constant.WxPayConstants;
 import com.github.binarywang.wxpay.constant.WxPayConstants.SignType;
 import com.github.binarywang.wxpay.constant.WxPayConstants.TradeType;
 import com.github.binarywang.wxpay.exception.WxPayException;
+import com.github.binarywang.wxpay.exception.WxSignTestException;
 import com.github.binarywang.wxpay.service.*;
 import com.github.binarywang.wxpay.util.SignUtils;
 import com.github.binarywang.wxpay.util.XmlConfig;
@@ -343,7 +344,11 @@ public abstract class BaseWxPayServiceImpl implements WxPayService {
    * @param data   通知数据
    * @return true:校验通过 false:校验不通过
    */
-  private boolean verifyNotifySign(SignatureHeader header, String data) {
+  private boolean verifyNotifySign(SignatureHeader header, String data) throws WxSignTestException {
+    String wxPaySign = header.getSignature();
+    if(wxPaySign.startsWith("WECHATPAY/SIGNTEST/")){
+      throw new WxSignTestException("微信支付签名探测流量");
+    }
     String beforeSign = String.format("%s\n%s\n%s\n",
       header.getTimeStamp(),
       header.getNonce(),

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/PayScoreServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/PayScoreServiceImpl.java
@@ -7,6 +7,7 @@ import com.github.binarywang.wxpay.bean.payscore.WxPayScoreRequest;
 import com.github.binarywang.wxpay.bean.payscore.WxPayScoreResult;
 import com.github.binarywang.wxpay.config.WxPayConfig;
 import com.github.binarywang.wxpay.exception.WxPayException;
+import com.github.binarywang.wxpay.exception.WxSignTestException;
 import com.github.binarywang.wxpay.service.PayScoreService;
 import com.github.binarywang.wxpay.service.WxPayService;
 import com.github.binarywang.wxpay.v3.util.AesUtils;
@@ -327,7 +328,11 @@ public class PayScoreServiceImpl implements PayScoreService {
    * @param data   通知数据
    * @return true:校验通过 false:校验不通过
    */
-  private boolean verifyNotifySign(SignatureHeader header, String data) {
+  private boolean verifyNotifySign(SignatureHeader header, String data) throws WxSignTestException {
+    String wxPaySign = header.getSigned();
+    if(wxPaySign.startsWith("WECHATPAY/SIGNTEST/")){
+      throw new WxSignTestException("微信支付签名探测流量");
+    }
     String beforeSign = String.format("%s\n%s\n%s\n", header.getTimeStamp(), header.getNonce(), data);
     return payService.getConfig().getVerifier().verify(header.getSerialNo(),
       beforeSign.getBytes(StandardCharsets.UTF_8), header.getSigned());


### PR DESCRIPTION
微信支付的[签名探测](https://pay.weixin.qq.com/docs/merchant/development/interface-rules/signature-verification.html#%E5%BA%94%E5%AF%B9%E7%AD%BE%E5%90%8D%E6%8E%A2%E6%B5%8B%E6%B5%81%E9%87%8F)，会生成"WECHATPAY/SIGNTEST/"开头的签名值，导致签名base64解码异常。
统一处理下。关联Issues #3288