### PR TITLE
new: #3402 [微信支付]支持配置微信支付公钥

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/v3/auth/PublicCertificateVerifier.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/v3/auth/PublicCertificateVerifier.java
@@ -1,0 +1,39 @@
+package com.github.binarywang.wxpay.v3.auth;
+
+import java.security.*;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import me.chanjar.weixin.common.error.WxRuntimeException;
+
+public class PublicCertificateVerifier implements Verifier{
+
+    private final PublicKey publicKey;
+
+    private final X509PublicCertificate publicCertificate;
+
+    public PublicCertificateVerifier(PublicKey publicKey, String publicId) {
+        this.publicKey = publicKey;
+        this.publicCertificate = new X509PublicCertificate(publicKey, publicId);
+    }
+
+    @Override
+    public boolean verify(String serialNumber, byte[] message, String signature) {
+        try {
+            Signature sign = Signature.getInstance("SHA256withRSA");
+            sign.initVerify(publicKey);
+            sign.update(message);
+            return sign.verify(Base64.getDecoder().decode(signature));
+        } catch (NoSuchAlgorithmException e) {
+            throw new WxRuntimeException("当前Java环境不支持SHA256withRSA", e);
+        } catch (SignatureException e) {
+            throw new WxRuntimeException("签名验证过程发生了错误", e);
+        } catch (InvalidKeyException e) {
+            throw new WxRuntimeException("无效的证书", e);
+        }
+    }
+
+    @Override
+    public X509Certificate getValidCertificate() {
+        return this.publicCertificate;
+    }
+}

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/v3/auth/X509PublicCertificate.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/v3/auth/X509PublicCertificate.java
@@ -1,0 +1,150 @@
+package com.github.binarywang.wxpay.v3.auth;
+
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+public class X509PublicCertificate extends X509Certificate {
+
+    private final PublicKey publicKey;
+
+    private final String publicId;
+
+    public X509PublicCertificate(PublicKey publicKey, String publicId) {
+        this.publicKey = publicKey;
+        this.publicId = publicId;
+    }
+
+    @Override
+    public PublicKey getPublicKey() {
+        return this.publicKey;
+    }
+
+    @Override
+    public BigInteger getSerialNumber() {
+        return new BigInteger(publicId.replace("PUB_KEY_ID_", ""), 16);
+    }
+
+    @Override
+    public void checkValidity() throws CertificateExpiredException, CertificateNotYetValidException {
+    }
+
+    @Override
+    public void checkValidity(Date date) throws CertificateExpiredException, CertificateNotYetValidException {
+
+    }
+
+    @Override
+    public int getVersion() {
+        return 0;
+    }
+
+    @Override
+    public Principal getIssuerDN() {
+        return null;
+    }
+
+    @Override
+    public Principal getSubjectDN() {
+        return null;
+    }
+
+    @Override
+    public Date getNotBefore() {
+        return null;
+    }
+
+    @Override
+    public Date getNotAfter() {
+        return null;
+    }
+
+    @Override
+    public byte[] getTBSCertificate() throws CertificateEncodingException {
+        return new byte[0];
+    }
+
+    @Override
+    public byte[] getSignature() {
+        return new byte[0];
+    }
+
+    @Override
+    public String getSigAlgName() {
+        return "";
+    }
+
+    @Override
+    public String getSigAlgOID() {
+        return "";
+    }
+
+    @Override
+    public byte[] getSigAlgParams() {
+        return new byte[0];
+    }
+
+    @Override
+    public boolean[] getIssuerUniqueID() {
+        return new boolean[0];
+    }
+
+    @Override
+    public boolean[] getSubjectUniqueID() {
+        return new boolean[0];
+    }
+
+    @Override
+    public boolean[] getKeyUsage() {
+        return new boolean[0];
+    }
+
+    @Override
+    public int getBasicConstraints() {
+        return 0;
+    }
+
+    @Override
+    public byte[] getEncoded() throws CertificateEncodingException {
+        return new byte[0];
+    }
+
+    @Override
+    public void verify(PublicKey key) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
+
+    }
+
+    @Override
+    public void verify(PublicKey key, String sigProvider) throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException, SignatureException {
+
+    }
+
+    @Override
+    public String toString() {
+        return "";
+    }
+
+
+    @Override
+    public boolean hasUnsupportedCriticalExtension() {
+        return false;
+    }
+
+    @Override
+    public Set<String> getCriticalExtensionOIDs() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> getNonCriticalExtensionOIDs() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public byte[] getExtensionValue(String oid) {
+        return new byte[0];
+    }
+}

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/v3/util/PemUtils.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/v3/util/PemUtils.java
@@ -1,13 +1,12 @@
 package com.github.binarywang.wxpay.v3.util;
 
-import me.chanjar.weixin.common.error.WxRuntimeException;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateFactory;
@@ -15,7 +14,9 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
+import me.chanjar.weixin.common.error.WxRuntimeException;
 
 public class PemUtils {
 
@@ -57,6 +58,30 @@ public class PemUtils {
       throw new WxRuntimeException("证书尚未生效", e);
     } catch (CertificateException e) {
       throw new WxRuntimeException("无效的证书", e);
+    }
+  }
+
+  public static PublicKey loadPublicKey(InputStream inputStream){
+    try {
+      ByteArrayOutputStream array = new ByteArrayOutputStream();
+      byte[] buffer = new byte[1024];
+      int length;
+      while ((length = inputStream.read(buffer)) != -1) {
+        array.write(buffer, 0, length);
+      }
+
+      String publicKey = array.toString("utf-8")
+        .replace("-----BEGIN PUBLIC KEY-----", "")
+        .replace("-----END PUBLIC KEY-----", "")
+        .replaceAll("\\s+", "");
+      return KeyFactory.getInstance("RSA")
+        .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(publicKey)));
+    } catch (NoSuchAlgorithmException e) {
+      throw new WxRuntimeException("当前Java环境不支持RSA", e);
+    } catch (InvalidKeySpecException e) {
+      throw new WxRuntimeException("无效的密钥格式");
+    } catch (IOException e) {
+      throw new WxRuntimeException("无效的密钥");
     }
   }
 }

--- a/weixin-java-pay/src/test/resources/test-config.sample.xml
+++ b/weixin-java-pay/src/test/resources/test-config.sample.xml
@@ -18,6 +18,7 @@
   <certSerialNo>apiV3 证书序列号值</certSerialNo>
   <privateKeyPath>apiclient_key.pem证书文件的绝对路径或者以classpath:开头的类路径.</privateKeyPath>
   <privateCertPath>apiclient_cert.pem证书文件的绝对路径或者以classpath:开头的类路径.</privateCertPath>
+  <publicKeyPath>pub_key.pem证书文件的绝对路径或者以classpath:开头的类路径.</publicKeyPath>
 
   <!-- other配置 -->
   <openid>某个openId</openid>


### PR DESCRIPTION
### 内容描述

微信支付功能支持配置微信支付公钥, 如果配置了公钥则优先使用公钥验签.

[ISSUES](https://github.com/binarywang/WxJava/issues/3402)
[参考内容](https://blog.csdn.net/qq_37391200/article/details/143508109)

### 测试情况

已测试收银台支付 订单退款. 其他业务由于资源限制无法测试.