### PR TITLE
bug: #3443 初始化V3请求时私钥取消加密

### DIFF
--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/config/CustomizedWxPayConfigTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/config/CustomizedWxPayConfigTest.java
@@ -1,5 +1,9 @@
 package com.github.binarywang.wxpay.config;
 
+import static org.testng.Assert.assertEquals;
+
+import com.github.binarywang.wxpay.bean.result.WxPayOrderQueryV3Result;
+import com.github.binarywang.wxpay.constant.WxPayErrorCode;
 import com.github.binarywang.wxpay.exception.WxPayException;
 import com.github.binarywang.wxpay.service.WxPayService;
 import com.github.binarywang.wxpay.testbase.CustomizedApiTestModule;
@@ -30,10 +34,9 @@ public class CustomizedWxPayConfigTest {
 
   public void testCustomizerV3HttpClient() {
     try {
-      wxPayService.queryOrderV3("a", null);
+      WxPayOrderQueryV3Result result = wxPayService.queryOrderV3("a", null);
     } catch (WxPayException e) {
-      // ignore
-      e.printStackTrace();
+      assertEquals(e.getErrCode(), WxPayErrorCode.RefundQuery.PARAM_ERROR);
     }
   }
 }

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/testbase/CustomizedApiTestModule.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/testbase/CustomizedApiTestModule.java
@@ -6,14 +6,13 @@ import com.github.binarywang.wxpay.service.impl.WxPayServiceImpl;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.thoughtworks.xstream.XStream;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import me.chanjar.weixin.common.error.WxRuntimeException;
 import me.chanjar.weixin.common.util.xml.XStreamInitializer;
 import org.apache.http.HttpRequestInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * The type Api test module.
@@ -39,7 +38,22 @@ public class CustomizedApiTestModule implements Module {
       config.setHttpClientBuilderCustomizer((builder) -> {
         builder.addInterceptorLast((HttpRequestInterceptor) (r, c) -> System.out.println("--------> HttpRequestInterceptor ..."));
       });
+      try (FileInputStream fis = new FileInputStream(config.getPrivateKeyPath());
+           InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
+           BufferedReader reader = new BufferedReader(isr)) {
 
+        StringBuilder stringBuilder = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+          stringBuilder.append(line);
+          stringBuilder.append(System.lineSeparator());
+        }
+
+        String fileContent = stringBuilder.toString();
+        config.setPrivateKeyString(fileContent);
+        System.out.println(fileContent);
+
+      }
       WxPayService wxService = new WxPayServiceImpl();
       wxService.setConfig(config);
 


### PR DESCRIPTION
修复了Issue: #3443 中的问题

问题来源: commit: [fe5430e](https://github.com/binarywang/WxJava/commit/fe5430ee65fccea583378484b1c89b5fd5bbe286)