### PR TITLE
bug: #3443 [微信支付] 私钥字符串在初始化时不需要编码转换

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -14,7 +14,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.util.Base64;
 import java.util.Optional;
 import javax.net.ssl.SSLContext;
 import lombok.Data;
@@ -295,10 +294,6 @@ public class WxPayConfig {
     }
     try {
       if (merchantPrivateKey == null) {
-        if (StringUtils.isNotBlank(this.getPrivateKeyString())) {
-          this.setPrivateKeyString(Base64.getEncoder().encodeToString(this.getPrivateKeyString().getBytes()));
-        }
-
         try (InputStream keyInputStream = this.loadConfigInputStream(this.getPrivateKeyString(), this.getPrivateKeyPath(),
           this.privateKeyContent, "privateKeyPath")) {
           merchantPrivateKey = PemUtils.loadPrivateKey(keyInputStream);

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/config/CustomizedWxPayConfigTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/config/CustomizedWxPayConfigTest.java
@@ -1,5 +1,9 @@
 package com.github.binarywang.wxpay.config;
 
+import static org.testng.Assert.assertEquals;
+
+import com.github.binarywang.wxpay.bean.result.WxPayOrderQueryV3Result;
+import com.github.binarywang.wxpay.constant.WxPayErrorCode;
 import com.github.binarywang.wxpay.exception.WxPayException;
 import com.github.binarywang.wxpay.service.WxPayService;
 import com.github.binarywang.wxpay.testbase.CustomizedApiTestModule;
@@ -30,10 +34,9 @@ public class CustomizedWxPayConfigTest {
 
   public void testCustomizerV3HttpClient() {
     try {
-      wxPayService.queryOrderV3("a", null);
+      WxPayOrderQueryV3Result result = wxPayService.queryOrderV3("a", null);
     } catch (WxPayException e) {
-      // ignore
-      e.printStackTrace();
+      assertEquals(e.getErrCode(), WxPayErrorCode.RefundQuery.PARAM_ERROR);
     }
   }
 }

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/config/WxPayConfigTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/config/WxPayConfigTest.java
@@ -1,15 +1,12 @@
 package com.github.binarywang.wxpay.config;
 
-import com.github.binarywang.wxpay.exception.WxPayException;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.pqc.jcajce.provider.util.KeyUtil;
-import org.testng.annotations.Test;
-
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.util.Base64;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.testng.annotations.Test;
 
 /**
  * <pre>

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/config/WxPayConfigTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/config/WxPayConfigTest.java
@@ -1,11 +1,5 @@
 package com.github.binarywang.wxpay.config;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.SecureRandom;
-import java.security.Security;
-import java.util.Base64;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -49,21 +43,6 @@ public class WxPayConfigTest {
     payConfig.setMchId("123");
     payConfig.setKeyString("MIIKmgIBAzCCCmQGCS...");
     payConfig.initSSLContext();
-  }
-
-
-  @Test
-  public void testInitApiV3HttpClient() throws Exception {
-    Security.addProvider(new BouncyCastleProvider());
-    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA","BC");
-    keyPairGenerator.initialize(2048,new SecureRandom());
-    KeyPair keyPair = keyPairGenerator.genKeyPair();
-    byte[] encoded = keyPair.getPrivate().getEncoded();
-    // 模拟用户配置
-    String privateKeyString = Base64.getEncoder().encodeToString(encoded);
-    payConfig.setPrivateKeyString(privateKeyString);
-    payConfig.setApiV3Key("Test");
-    payConfig.initApiV3HttpClient();
   }
 
 }

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/testbase/CustomizedApiTestModule.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/testbase/CustomizedApiTestModule.java
@@ -6,14 +6,13 @@ import com.github.binarywang.wxpay.service.impl.WxPayServiceImpl;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.thoughtworks.xstream.XStream;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import me.chanjar.weixin.common.error.WxRuntimeException;
 import me.chanjar.weixin.common.util.xml.XStreamInitializer;
 import org.apache.http.HttpRequestInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * The type Api test module.
@@ -39,7 +38,22 @@ public class CustomizedApiTestModule implements Module {
       config.setHttpClientBuilderCustomizer((builder) -> {
         builder.addInterceptorLast((HttpRequestInterceptor) (r, c) -> System.out.println("--------> HttpRequestInterceptor ..."));
       });
+      try (FileInputStream fis = new FileInputStream(config.getPrivateKeyPath());
+           InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
+           BufferedReader reader = new BufferedReader(isr)) {
 
+        StringBuilder stringBuilder = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+          stringBuilder.append(line);
+          stringBuilder.append(System.lineSeparator());
+        }
+
+        String fileContent = stringBuilder.toString();
+        config.setPrivateKeyString(fileContent);
+        System.out.println(fileContent);
+
+      }
       WxPayService wxService = new WxPayServiceImpl();
       wxService.setConfig(config);
 


### PR DESCRIPTION
修复 Issue #3443 中由于私钥进行Base64编码导致的问题
问题来源 Commit: [fe5430e](https://github.com/binarywang/WxJava/commit/fe5430ee65fccea583378484b1c89b5fd5bbe286)