### PR TITLE
:bug: 【微信支付】平台证书切换微信支付公钥模式过程中（两种模式并存）Wechatpay-Serial 需要传完整的公钥id给微信标识…

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
@@ -171,7 +171,12 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     HttpPost httpPost = this.createHttpPost(url, requestStr);
     httpPost.addHeader(ACCEPT, APPLICATION_JSON);
     httpPost.addHeader(CONTENT_TYPE, APPLICATION_JSON);
-    String serialNumber = getConfig().getVerifier().getValidCertificate().getSerialNumber().toString(16).toUpperCase();
+
+   // 微信支付 平台证书切换微信支付公钥模式过程中（两种模式并存）Wechatpay-Serial 需要传完整的公钥id给微信标识使用什么签名方式
+    String serialNumber = StringUtils.isEmpty(getConfig().getPublicKeyId()) ?
+      getConfig().getVerifier().getValidCertificate().getSerialNumber().toString(16).toUpperCase() :
+      getConfig().getPublicKeyId();
+
     httpPost.addHeader("Wechatpay-Serial", serialNumber);
     try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
       //v3已经改为通过状态码判断200 204 成功
@@ -251,7 +256,12 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     HttpGet httpGet = new HttpGet(url);
     httpGet.addHeader(ACCEPT, APPLICATION_JSON);
     httpGet.addHeader(CONTENT_TYPE, APPLICATION_JSON);
-    String serialNumber = getConfig().getVerifier().getValidCertificate().getSerialNumber().toString(16).toUpperCase();
+
+    // 微信支付 平台证书切换微信支付公钥模式过程中（两种模式并存）Wechatpay-Serial 需要传完整的公钥id给微信标识使用什么签名方式
+    String serialNumber = StringUtils.isEmpty(getConfig().getPublicKeyId()) ?
+      getConfig().getVerifier().getValidCertificate().getSerialNumber().toString(16).toUpperCase() :
+      getConfig().getPublicKeyId();
+
     httpGet.addHeader("Wechatpay-Serial", serialNumber);
     return this.requestV3(url, httpGet);
   }


### PR DESCRIPTION
微信在后台进行申请微信支付公钥后，平台证书切换微信支付公钥模式过程中（两种模式并存）Wechatpay-Serial 需要传完整的公钥id给微信标识使用什么签名方式。
官方文档地址：https://pay.weixin.qq.com/docs/merchant/products/platform-certificate/update-pub-key.html#