### PR TITLE
:bug: #3054 【小程序】使用jdk提供的不可变map，避免gson的问题

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/BaseWxMaServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/BaseWxMaServiceImpl.java
@@ -499,7 +499,10 @@ public abstract class BaseWxMaServiceImpl<H, P> implements WxMaService, RequestH
   @Override
   public void setWxMaConfig(WxMaConfig maConfig) {
     final String appid = maConfig.getAppid();
-    this.setMultiConfigs(ImmutableMap.of(appid, maConfig), appid);
+    Map<String, WxMaConfig> map = new HashMap<>();
+    map.put(appid, maConfig);
+    Map<String, WxMaConfig> configMap = Collections.unmodifiableMap(map);
+    this.setMultiConfigs(configMap, appid);
   }
 
   @Override


### PR DESCRIPTION
这里设置配置使用了不可变的map，目前我用jdk中自带的一个集合实现了，绕过了gson的类