### PR TITLE
【企业微信】会话内容存档 - 解密后的会话内容实体类WxCpChatModel中send并不存在，send只是action变量的枚举值之一。

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/msgaudit/WxCpChatModel.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/msgaudit/WxCpChatModel.java
@@ -25,9 +25,6 @@ public class WxCpChatModel implements Serializable {
   @SerializedName("action")
   private String action;
 
-  @SerializedName("send")
-  private String send;
-
   @SerializedName("from")
   private String from;
 


### PR DESCRIPTION
依据：https://developer.work.weixin.qq.com/document/path/91774