### PR TITLE
fix: 【微信支付】修正 94aaff4 引入的错误读取证书问题

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -14,6 +14,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Optional;
 import javax.net.ssl.SSLContext;
 import lombok.Data;
@@ -371,7 +372,7 @@ public class WxPayConfig {
     if (configContent != null) {
       inputStream = new ByteArrayInputStream(configContent);
     } else if (StringUtils.isNotEmpty(configString)) {
-      configContent = configString.getBytes(StandardCharsets.UTF_8);
+      configContent = Base64.getDecoder().decode(configString);
       inputStream = new ByteArrayInputStream(configContent);
     } else {
       if (StringUtils.isBlank(configPath)) {


### PR DESCRIPTION
Fixes: #3443

https://github.com/binarywang/WxJava/commit/94aaff4c9439b22c58d51fd4471468107f5cf6d0 中对WxPayConfig进行了修改以解决 https://github.com/binarywang/WxJava/commit/fe5430ee65fccea583378484b1c89b5fd5bbe286 引入的问题。但是 `loadConfigInputStream(String configString, String configPath, byte[] configContent, String fileName)` 中的 `configString` 从引入项目开始就一直是设计为只处理base64字符串的。见 `privateKeyString` 等成员变量的注释：https://github.com/binarywang/WxJava/blob/704fba4d853d5f65ae7372b38b4fd3ba9e2caba1/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java#L112-L115