### PR TITLE
fix: 企业微信-家校沟通获取部门列表时,如果部门id为空则获取全量组织架构

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpSchoolUserService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpSchoolUserService.java
@@ -334,7 +334,7 @@ public interface WxCpSchoolUserService {
    * 请求方式：GET（HTTPS）
    * 请求地址：https://qyapi.weixin.qq.com/cgi-bin/school/department/list?access_token=ACCESS_TOKEN&id=ID
    *
-   * @param id the id
+   * @param id 部门id。获取指定部门及其下的子部门。 如果不填，默认获取全量组织架构
    * @return wx cp department list
    * @throws WxErrorException the wx error exception
    */

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpSchoolUserServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpSchoolUserServiceImpl.java
@@ -16,6 +16,7 @@ import me.chanjar.weixin.cp.bean.school.user.*;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.ExternalContact.*;
 import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.School.*;
@@ -246,7 +247,7 @@ public class WxCpSchoolUserServiceImpl implements WxCpSchoolUserService {
 
   @Override
   public WxCpDepartmentList listDepartment(Integer id) throws WxErrorException {
-    String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(DEPARTMENT_LIST) + id;
+    String apiUrl = Objects.isNull(id) ? this.cpService.getWxCpConfigStorage().getApiUrl(DEPARTMENT_LIST) : String.format("%s?id=%s", this.cpService.getWxCpConfigStorage().getApiUrl(DEPARTMENT_LIST), id);
     String responseContent = this.cpService.get(apiUrl, null);
     return WxCpDepartmentList.fromJson(responseContent);
   }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -691,7 +691,7 @@ public interface WxCpApiPathConsts {
     /**
      * The constant DEPARTMENT_LIST.
      */
-    String DEPARTMENT_LIST = "/cgi-bin/school/department/list?id=";
+    String DEPARTMENT_LIST = "/cgi-bin/school/department/list";
 
     /**
      * The constant GET_PAYMENT_RESULT.

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpSchoolUserServiceImplTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpSchoolUserServiceImplTest.java
@@ -1,0 +1,139 @@
+package me.chanjar.weixin.cp.api.impl;
+
+import com.google.gson.Gson;
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.cp.api.WxCpService;
+import me.chanjar.weixin.cp.bean.school.user.WxCpDepartmentList;
+import me.chanjar.weixin.cp.config.impl.WxCpDefaultConfigImpl;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.School.DEPARTMENT_LIST;
+import static org.testng.Assert.assertEquals;
+
+public class WxCpSchoolUserServiceImplTest {
+
+
+  String allDeptListJson = "{\n" +
+    "\t\"errcode\": 0,\n" +
+    "\t\"errmsg\": \"ok\",\n" +
+    "\t\"departments\": [\n" +
+    "\t\t{\n" +
+    "\t\t\t\"name\": \"一年级\",\n" +
+    "\t\t\t\"parentid\": 1,\n" +
+    "\t\t\t\"id\": 2,\n" +
+    "\t\t\t\"type\":2,\n" +
+    "\t\t\t\"register_year\":2018,\n" +
+    "\t\t\t\"standard_grade\":1,\n" +
+    "\t\t\t\"order\":1,\n" +
+    "\t\t\t\"department_admins\": [\n" +
+    "\t\t\t\t{\n" +
+    "\t\t\t\t\t\"userid\": \"zhangsan\",\n" +
+    "\t\t\t\t\t\"type\": 1\n" +
+    "\t\t\t\t},\n" +
+    "\t\t\t\t{\n" +
+    "\t\t\t\t\t\"userid\": \"lisi\",\n" +
+    "\t\t\t\t\t\"type\": 2\n" +
+    "\t\t\t\t}\n" +
+    "\t\t\t],\n" +
+    "            \"is_graduated\": 0\n" +
+    "\t\t},\n" +
+    "\t\t{\n" +
+    "\t\t\t\"name\": \"一年级一班\",\n" +
+    "\t\t\t\"parentid\": 1,\n" +
+    "\t\t\t\"id\": 3,\n" +
+    "\t\t\t\"type\": 1,\n" +
+    "\t\t\t\"department_admins\": [\n" +
+    "\t\t\t\t{\n" +
+    "\t\t\t\t\t\"userid\": \"zhangsan\",\n" +
+    "\t\t\t\t\t\"type\": 3,\n" +
+    "\t\t\t\t\t\"subject\":\"语文\"\n" +
+    "\t\t\t\t},\n" +
+    "\t\t\t\t{\n" +
+    "\t\t\t\t\t\"userid\": \"lisi\",\n" +
+    "\t\t\t\t\t\"type\": 4,\n" +
+    "\t\t\t\t\t\"subject\":\"数学\"\n" +
+    "\t\t\t\t}\n" +
+    "\t\t\t],\n" +
+    "\t\t\t\"open_group_chat\": 1,\n" +
+    "            \"group_chat_id\": \"group_chat_id\"\n" +
+    "\t\t}\n" +
+    "\t]\n" +
+    "}\n";
+
+  String deptId3Json = "{\n" +
+    "  \"errcode\": 0,\n" +
+    "  \"errmsg\": \"ok\",\n" +
+    "  \"departments\": [\n" +
+    "    {\n" +
+    "      \"name\": \"一年级一班\",\n" +
+    "      \"parentid\": 1,\n" +
+    "      \"id\": 3,\n" +
+    "      \"type\": 1,\n" +
+    "      \"department_admins\": [\n" +
+    "        {\n" +
+    "          \"userid\": \"zhangsan\",\n" +
+    "          \"type\": 3,\n" +
+    "          \"subject\":\"语文\"\n" +
+    "        },\n" +
+    "        {\n" +
+    "          \"userid\": \"lisi\",\n" +
+    "          \"type\": 4,\n" +
+    "          \"subject\":\"数学\"\n" +
+    "        }\n" +
+    "      ],\n" +
+    "      \"open_group_chat\": 1,\n" +
+    "      \"group_chat_id\": \"group_chat_id\"\n" +
+    "    }\n" +
+    "  ]\n" +
+    "}";
+
+  String deptId2Json = "{\n" +
+    "  \"errcode\": 0,\n" +
+    "  \"errmsg\": \"ok\",\n" +
+    "  \"departments\": []\n" +
+    "}\n";
+
+
+  @Test
+  public void testListDepartmentWhenIdIsNull() throws WxErrorException {
+
+    WxCpService mockCpService = Mockito.mock(WxCpService.class);
+    WxCpSchoolUserServiceImpl wxCpSchoolUserService = new WxCpSchoolUserServiceImpl(mockCpService);
+    Mockito.when(mockCpService.getWxCpConfigStorage()).thenReturn(new WxCpDefaultConfigImpl());
+    Mockito.when(mockCpService.get(mockCpService.getWxCpConfigStorage().getApiUrl(DEPARTMENT_LIST), null)).thenReturn(allDeptListJson);
+    WxCpDepartmentList wxCpDepartmentList = wxCpSchoolUserService.listDepartment(null);
+    //WxCpDepartmentList没有重写Equals和Hashcode,不能直接比较
+    Gson gson = new Gson();
+    assertEquals(gson.toJson(wxCpDepartmentList), gson.toJson(gson.fromJson(allDeptListJson, WxCpDepartmentList.class)), "should be equal");
+
+  }
+
+  @Test
+  public void testListDepartmentWhenIdIs2() throws WxErrorException {
+
+    WxCpService mockCpService = Mockito.mock(WxCpService.class);
+    WxCpSchoolUserServiceImpl wxCpSchoolUserService = new WxCpSchoolUserServiceImpl(mockCpService);
+    Mockito.when(mockCpService.getWxCpConfigStorage()).thenReturn(new WxCpDefaultConfigImpl());
+    Gson gson = new Gson();
+    int deptId = 2;
+    Mockito.when(mockCpService.get(String.format("%s?id=%s", mockCpService.getWxCpConfigStorage().getApiUrl(DEPARTMENT_LIST), deptId), null)).thenReturn(deptId2Json);
+    //WxCpDepartmentList没有重写Equals和Hashcode,不能直接比较
+    assertEquals(gson.toJson(wxCpSchoolUserService.listDepartment(deptId)), gson.toJson(gson.fromJson(deptId2Json, WxCpDepartmentList.class)), "should be equal");
+
+  }
+
+  @Test
+  public void testListDepartmentWhenIdIs3() throws WxErrorException {
+
+    WxCpService mockCpService = Mockito.mock(WxCpService.class);
+    WxCpSchoolUserServiceImpl wxCpSchoolUserService = new WxCpSchoolUserServiceImpl(mockCpService);
+    Mockito.when(mockCpService.getWxCpConfigStorage()).thenReturn(new WxCpDefaultConfigImpl());
+    Gson gson = new Gson();
+    int deptId = 3;
+    Mockito.when(mockCpService.get(String.format("%s?id=%s", mockCpService.getWxCpConfigStorage().getApiUrl(DEPARTMENT_LIST), deptId), null)).thenReturn(deptId3Json);
+    //WxCpDepartmentList没有重写Equals和Hashcode,不能直接比较
+    assertEquals(gson.toJson(wxCpSchoolUserService.listDepartment(deptId)), gson.toJson(gson.fromJson(deptId3Json, WxCpDepartmentList.class)), "should be equal");
+
+  }
+}


### PR DESCRIPTION
issue #3458
https://developer.work.weixin.qq.com/document/path/92343