### PR TITLE
修复合单支付combineTransactions内部调用传参问题

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
@@ -808,7 +808,7 @@ public abstract class BaseWxPayServiceImpl implements WxPayService {
   @Override
   public <T> T combineTransactions(TradeTypeEnum tradeType, CombineTransactionsRequest request) throws WxPayException {
     CombineTransactionsResult result = this.combine(tradeType, request);
-    return result.getPayInfo(tradeType, request.getCombineAppid(), request.getCombineAppid(), this.getConfig().getPrivateKey());
+    return result.getPayInfo(tradeType, request.getCombineAppid(), request.getCombineMchid(), this.getConfig().getPrivateKey());
   }
 
   @Override


### PR DESCRIPTION
weixin-java-pay模块BaseWxPayServiceImpl类中combineTransactions方法内部调用CombineTransactionsResult类的getPayInfo方法传参异常，第三个入参应为mchId
![WX20250212-090413@2x](https://github.com/user-attachments/assets/d4ab517f-bf30-42d3-803e-a021346dbabe)
![WX20250212-091029@2x](https://github.com/user-attachments/assets/6127a8e5-7c7d-4fdb-8f23-2934af120ca4)
