### PR TITLE
#3532 在解析回调内容时，直接调用getConfig()，而不是临时拼一次configKey，因为getConfig()中的逻辑是：当…

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
@@ -323,14 +323,13 @@ public abstract class BaseWxPayServiceImpl implements WxPayService {
       log.debug("微信支付异步通知请求参数：{}", xmlData);
       WxPayOrderNotifyResult result = WxPayOrderNotifyResult.fromXML(xmlData);
       if (signType == null) {
-        String configKey = this.getConfigKey(result.getMchId(), result.getAppid());
+        this.switchover(result.getMchId(), result.getAppid());
         if (result.getSignType() != null) {
           // 如果解析的通知对象中signType有值，则使用它进行验签
           signType = result.getSignType();
-        } else if (configMap.get(configKey).getSignType() != null) {
+        } else if (this.getConfig().getSignType() != null) {
           // 如果配置中signType有值，则使用它进行验签
-          signType = configMap.get(configKey).getSignType();
-          this.switchover(result.getMchId(), result.getAppid());
+          signType = this.getConfig().getSignType();
         }
       }
 


### PR DESCRIPTION
…仅有一个configMap仅有一个元素时，直接返回此元素，方便使用同一个商户号用于多个小程序的开发者

#3532 在解析回调内容时，直接调用getConfig()，而不是临时拼一次configKey，因为getConfig()中的逻辑是：当仅有一个configMap仅有一个元素时，直接返回此元素，方便使用同一个商户号用于多个小程序的开发者