### PR TITLE
修复获取解密聊天消息，转换文件消息，出现fileSize的类型转换异常的bug

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/msgaudit/WxCpChatModel.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/msgaudit/WxCpChatModel.java
@@ -603,7 +603,7 @@ public class WxCpChatModel implements Serializable {
     private String sdkFileId;
 
     @SerializedName("filesize")
-    private Integer fileSize;
+    private Long fileSize;
 
     /**
      * From json file.


### PR DESCRIPTION
简要描述
获取解密聊天消息，转换文件消息，出现fileSize的类型转换异常

详见
https://github.com/binarywang/WxJava/issues/3558