### PR TITLE
【微信支付】支持完全公钥模式

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/VerifierBuilder.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/VerifierBuilder.java
@@ -93,6 +93,16 @@ class VerifierBuilder {
   }
 
   /**
+   * 针对完全使用公钥的场景
+   * @param publicKeyId 公钥id
+   * @param publicKey 公钥
+   * @return
+   */
+  static Verifier buildPublicCertVerifier(String publicKeyId, PublicKey publicKey) {
+    return getPublicCertVerifier(publicKeyId, publicKey, null);
+  }
+
+  /**
    * 获取证书验证器.
    *
    * @param certSerialNo       certSerialNo

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -300,13 +300,13 @@ public class WxPayConfig {
       this.certSerialNo = certificate.getSerialNumber().toString(16).toUpperCase();
     }
     try {
-      if (merchantPrivateKey == null) {
+      if (merchantPrivateKey == null && StringUtils.isNotBlank(this.getPrivateKeyPath())) {
         try (InputStream keyInputStream = this.loadConfigInputStream(this.getPrivateKeyString(), this.getPrivateKeyPath(),
           this.privateKeyContent, "privateKeyPath")) {
           merchantPrivateKey = PemUtils.loadPrivateKey(keyInputStream);
         }
       }
-      if (certificate == null && StringUtils.isBlank(this.getCertSerialNo())) {
+      if (certificate == null && StringUtils.isBlank(this.getCertSerialNo()) && StringUtils.isNotBlank(this.getPrivateCertPath())) {
         try (InputStream certInputStream = this.loadConfigInputStream(this.getPrivateCertString(), this.getPrivateCertPath(),
           this.privateCertContent, "privateCertPath")) {
           certificate = PemUtils.loadCertificate(certInputStream);

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -316,7 +316,7 @@ public class WxPayConfig {
           publicKey = PemUtils.loadPublicKey(pubInputStream);
         }
       } else {
-        // 使用完全公钥模式时，同时兼容平台证书和公钥
+        // 不使用完全公钥模式时，同时兼容平台证书和公钥
         X509Certificate certificate = null;
         // 尝试从p12证书中加载私钥和证书
         Object[] objects = this.p12ToPem();

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -295,13 +295,13 @@ public class WxPayConfig {
       this.certSerialNo = certificate.getSerialNumber().toString(16).toUpperCase();
     }
     try {
-      if (merchantPrivateKey == null) {
+      if (merchantPrivateKey == null && StringUtils.isNotBlank(this.getPrivateKeyPath())) {
         try (InputStream keyInputStream = this.loadConfigInputStream(this.getPrivateKeyString(), this.getPrivateKeyPath(),
           this.privateKeyContent, "privateKeyPath")) {
           merchantPrivateKey = PemUtils.loadPrivateKey(keyInputStream);
         }
       }
-      if (certificate == null && StringUtils.isBlank(this.getCertSerialNo())) {
+      if (certificate == null && StringUtils.isBlank(this.getCertSerialNo()) && StringUtils.isNotBlank(this.getPrivateCertPath())) {
         try (InputStream certInputStream = this.loadConfigInputStream(this.getPrivateCertString(), this.getPrivateCertPath(),
           this.privateCertContent, "privateCertPath")) {
           certificate = PemUtils.loadCertificate(certInputStream);

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -233,6 +233,11 @@ public class WxPayConfig {
   private boolean strictlyNeedWechatPaySerial = false;
 
   /**
+   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认不使用
+   */
+  private boolean fullPublicKeyModel = false;
+
+  /**
    * 返回所设置的微信支付接口请求地址域名.
    *
    * @return 微信支付接口请求地址域名
@@ -289,36 +294,61 @@ public class WxPayConfig {
     if (StringUtils.isBlank(this.getApiV3Key())) {
       throw new WxPayException("请确保apiV3Key值已设置");
     }
-
-    // 尝试从p12证书中加载私钥和证书
-    PrivateKey merchantPrivateKey = null;
-    X509Certificate certificate = null;
-    Object[] objects = this.p12ToPem();
-    if (objects != null) {
-      merchantPrivateKey = (PrivateKey) objects[0];
-      certificate = (X509Certificate) objects[1];
-      this.certSerialNo = certificate.getSerialNumber().toString(16).toUpperCase();
-    }
     try {
+      PrivateKey merchantPrivateKey = null;
+      PublicKey publicKey = null;
+
+      // 使用完全公钥模式时，只加载公钥相关配置，避免下载平台证书使灰度切换无法达到100%覆盖
+      if (this.fullPublicKeyModel) {
+        if (StringUtils.isBlank(this.getCertSerialNo())) {
+          throw new WxPayException("使用公钥模式时，请确保certSerialNo(apiV3证书序列号)值已设置");
+        }
+        if (StringUtils.isBlank(this.getPublicKeyId())) {
+          throw new WxPayException("使用公钥模式时，请确保publicKeyId值已设置");
+        }
+        if (StringUtils.isBlank(this.getPublicKeyString()) && StringUtils.isBlank(this.getPublicKeyPath()) && this.getPublicKeyContent() == null) {
+          throw new WxPayException("使用公钥模式时，请确保publicKeyString/publicKeyPath/publicKeyContent其中一项值已设置");
+        }
+
+        try (InputStream pubInputStream =
+               this.loadConfigInputStream(this.getPublicKeyString(), this.getPublicKeyPath(),
+                 this.getPublicKeyContent(), "publicKeyPath")) {
+          publicKey = PemUtils.loadPublicKey(pubInputStream);
+        }
+      } else {
+        // 使用完全公钥模式时，同时兼容平台证书和公钥
+        X509Certificate certificate = null;
+        // 尝试从p12证书中加载私钥和证书
+        Object[] objects = this.p12ToPem();
+        if (objects != null) {
+          merchantPrivateKey = (PrivateKey) objects[0];
+          certificate = (X509Certificate) objects[1];
+          this.certSerialNo = certificate.getSerialNumber().toString(16).toUpperCase();
+        }
+        if (certificate == null && StringUtils.isBlank(this.getCertSerialNo()) && StringUtils.isNotBlank(this.getPrivateCertPath())) {
+          try (InputStream certInputStream = this.loadConfigInputStream(this.getPrivateCertString(), this.getPrivateCertPath(),
+            this.privateCertContent, "privateCertPath")) {
+            certificate = PemUtils.loadCertificate(certInputStream);
+          }
+          this.certSerialNo = certificate.getSerialNumber().toString(16).toUpperCase();
+        }
+        if (this.getPublicKeyString() != null || this.getPublicKeyPath() != null || this.publicKeyContent != null) {
+          if (StringUtils.isBlank(this.getPublicKeyId())) {
+            throw new WxPayException("请确保和publicKeyId配套使用");
+          }
+          try (InputStream pubInputStream =
+                 this.loadConfigInputStream(this.getPublicKeyString(), this.getPublicKeyPath(),
+                   this.publicKeyContent, "publicKeyPath")) {
+            publicKey = PemUtils.loadPublicKey(pubInputStream);
+          }
+        }
+      }
+
+      // 加载api私钥
       if (merchantPrivateKey == null && StringUtils.isNotBlank(this.getPrivateKeyPath())) {
         try (InputStream keyInputStream = this.loadConfigInputStream(this.getPrivateKeyString(), this.getPrivateKeyPath(),
           this.privateKeyContent, "privateKeyPath")) {
           merchantPrivateKey = PemUtils.loadPrivateKey(keyInputStream);
-        }
-      }
-      if (certificate == null && StringUtils.isBlank(this.getCertSerialNo()) && StringUtils.isNotBlank(this.getPrivateCertPath())) {
-        try (InputStream certInputStream = this.loadConfigInputStream(this.getPrivateCertString(), this.getPrivateCertPath(),
-          this.privateCertContent, "privateCertPath")) {
-          certificate = PemUtils.loadCertificate(certInputStream);
-        }
-        this.certSerialNo = certificate.getSerialNumber().toString(16).toUpperCase();
-      }
-      PublicKey publicKey = null;
-      if (this.getPublicKeyString() != null || this.getPublicKeyPath() != null || this.publicKeyContent != null) {
-        try (InputStream pubInputStream =
-               this.loadConfigInputStream(this.getPublicKeyString(), this.getPublicKeyPath(),
-                 this.publicKeyContent, "publicKeyPath")) {
-          publicKey = PemUtils.loadPublicKey(pubInputStream);
         }
       }
 
@@ -326,11 +356,14 @@ public class WxPayConfig {
       WxPayHttpProxy wxPayHttpProxy = getWxPayHttpProxy();
 
       // 构造证书验签器
-      Verifier certificatesVerifier = VerifierBuilder.build(
-        this.getCertSerialNo(), this.getMchId(), this.getApiV3Key(), merchantPrivateKey, wxPayHttpProxy,
-        this.getCertAutoUpdateTime(), this.getPayBaseUrl(),
-        this.getPublicKeyId(), publicKey
-      );
+      Verifier certificatesVerifier;
+      if (this.fullPublicKeyModel) {
+        certificatesVerifier = VerifierBuilder.buildPublicCertVerifier(this.publicKeyId, publicKey);
+      } else {
+        certificatesVerifier = VerifierBuilder.build(
+          this.getCertSerialNo(), this.getMchId(), this.getApiV3Key(), merchantPrivateKey, wxPayHttpProxy,
+          this.getCertAutoUpdateTime(), this.getPayBaseUrl(), this.getPublicKeyId(), publicKey);
+      }
 
       WxPayV3HttpClientBuilder wxPayV3HttpClientBuilder = WxPayV3HttpClientBuilder.create()
         .withMerchant(mchId, certSerialNo, merchantPrivateKey)

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
@@ -105,8 +105,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
   }
 
   private String requestV3(String url, String requestStr, HttpRequestBase httpRequestBase) throws WxPayException {
-    try (CloseableHttpClient httpClient = this.createApiV3HttpClient();
-         CloseableHttpResponse response = httpClient.execute(httpRequestBase)) {
+    CloseableHttpClient httpClient = this.createApiV3HttpClient();
+    try (CloseableHttpResponse response = httpClient.execute(httpRequestBase)) {
       //v3已经改为通过状态码判断200 204 成功
       int statusCode = response.getStatusLine().getStatusCode();
       //post方法有可能会没有返回值的情况
@@ -142,8 +142,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
   public String postV3WithWechatpaySerial(String url, String requestStr) throws WxPayException {
     HttpPost httpPost = this.createHttpPost(url, requestStr);
     this.configureRequest(httpPost);
-    try (CloseableHttpClient httpClient = this.createApiV3HttpClient();
-         CloseableHttpResponse response = httpClient.execute(httpPost)) {
+    CloseableHttpClient httpClient = this.createApiV3HttpClient();
+    try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
       //v3已经改为通过状态码判断200 204 成功
       int statusCode = response.getStatusLine().getStatusCode();
       String responseString = "{}";
@@ -178,9 +178,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
   @Override
   public String requestV3(String url, HttpRequestBase httpRequest) throws WxPayException {
     this.configureRequest(httpRequest);
-
-    try (CloseableHttpClient httpClient = this.createApiV3HttpClient();
-         CloseableHttpResponse response = httpClient.execute(httpRequest)) {
+    CloseableHttpClient httpClient = this.createApiV3HttpClient();
+    try (CloseableHttpResponse response = httpClient.execute(httpRequest)) {
       //v3已经改为通过状态码判断200 204 成功
       int statusCode = response.getStatusLine().getStatusCode();
       //post方法有可能会没有返回值的情况
@@ -223,11 +222,9 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
   @Override
   public InputStream downloadV3(String url) throws WxPayException {
     HttpGet httpGet = new WxPayV3DownloadHttpGet(url);
-    httpGet.addHeader(ACCEPT, ContentType.WILDCARD.getMimeType());
-    String serialNumber = getWechatPaySerial(getConfig());
-    httpGet.addHeader(WECHAT_PAY_SERIAL, serialNumber);
-    try (CloseableHttpClient httpClient = this.createApiV3HttpClient();
-         CloseableHttpResponse response = httpClient.execute(httpGet)) {
+    this.configureRequest(httpGet);
+    CloseableHttpClient httpClient = this.createApiV3HttpClient();
+    try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
       //v3已经改为通过状态码判断200 204 成功
       int statusCode = response.getStatusLine().getStatusCode();
       Header contentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
@@ -65,7 +65,7 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
         httpPost.releaseConnection();
       }
     } catch (Exception e) {
-      this.logError( url, requestStr, e);
+      this.logError(url, requestStr, e);
       wxApiData.set(new WxPayApiData(url, requestStr, null, e.getMessage()));
       throw new WxPayException(e.getMessage(), e);
     }
@@ -170,8 +170,6 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
 
   @Override
   public String postV3(String url, HttpPost httpPost) throws WxPayException {
-    String serialNumber = getWechatPaySerial(getConfig());
-    httpPost.addHeader(WECHAT_PAY_SERIAL, serialNumber);
     return this.requestV3(url, httpPost);
   }
 
@@ -264,8 +262,11 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
 
   private void configureRequest(HttpRequestBase request) {
     String serialNumber = getWechatPaySerial(getConfig());
+    String method = request.getMethod();
     request.addHeader(ACCEPT, APPLICATION_JSON);
-    request.addHeader(CONTENT_TYPE, APPLICATION_JSON);
+    if (!method.equals("POST")) {
+      request.addHeader(CONTENT_TYPE, APPLICATION_JSON);
+    }
     request.addHeader(WECHAT_PAY_SERIAL, serialNumber);
 
     request.setConfig(RequestConfig.custom()

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
@@ -44,6 +44,7 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
   private static final String ACCEPT = "Accept";
   private static final String CONTENT_TYPE = "Content-Type";
   private static final String APPLICATION_JSON = "application/json";
+  private static final String WECHATPAY_SERIAL = "Wechatpay-Serial";
 
   @Override
   public byte[] postForBytes(String url, String requestStr, boolean useKey) throws WxPayException {
@@ -101,7 +102,7 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     httpPost.addHeader(ACCEPT, APPLICATION_JSON);
     httpPost.addHeader(CONTENT_TYPE, APPLICATION_JSON);
     String serialNumber = getWechatpaySerial(getConfig());
-    httpPost.addHeader("Wechatpay-Serial", serialNumber);
+    httpPost.addHeader(WECHATPAY_SERIAL, serialNumber);
     try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
       //v3已经改为通过状态码判断200 204 成功
       int statusCode = response.getStatusLine().getStatusCode();
@@ -133,6 +134,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
   public String patchV3(String url, String requestStr) throws WxPayException {
     CloseableHttpClient httpClient = this.createApiV3HttpClient();
     HttpPatch httpPatch = new HttpPatch(url);
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpPatch.addHeader(WECHATPAY_SERIAL, serialNumber);
     httpPatch.setEntity(this.createEntry(requestStr));
 
     httpPatch.setConfig(RequestConfig.custom()
@@ -204,6 +207,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
 
   @Override
   public String postV3(String url, HttpPost httpPost) throws WxPayException {
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpPost.addHeader(WECHATPAY_SERIAL, serialNumber);
     return this.requestV3(url, httpPost);
   }
 
@@ -249,6 +254,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     HttpGet httpGet = new HttpGet(url);
     httpGet.addHeader(ACCEPT, APPLICATION_JSON);
     httpGet.addHeader(CONTENT_TYPE, APPLICATION_JSON);
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpGet.addHeader(WECHATPAY_SERIAL, serialNumber);
     return this.requestV3(url, httpGet);
   }
 
@@ -258,7 +265,7 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     httpGet.addHeader(ACCEPT, APPLICATION_JSON);
     httpGet.addHeader(CONTENT_TYPE, APPLICATION_JSON);
     String serialNumber = getWechatpaySerial(getConfig());
-    httpGet.addHeader("Wechatpay-Serial", serialNumber);
+    httpGet.addHeader(WECHATPAY_SERIAL, serialNumber);
     return this.requestV3(url, httpGet);
   }
 
@@ -267,6 +274,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     CloseableHttpClient httpClient = this.createApiV3HttpClient();
     HttpGet httpGet = new WxPayV3DownloadHttpGet(url);
     httpGet.addHeader(ACCEPT, ContentType.WILDCARD.getMimeType());
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpGet.addHeader(WECHATPAY_SERIAL, serialNumber);
     try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
       //v3已经改为通过状态码判断200 204 成功
       int statusCode = response.getStatusLine().getStatusCode();
@@ -298,6 +307,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     httpPut.setEntity(entity);
     httpPut.addHeader(ACCEPT, APPLICATION_JSON);
     httpPut.addHeader(CONTENT_TYPE, APPLICATION_JSON);
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpPut.addHeader(WECHATPAY_SERIAL, serialNumber);
     return requestV3(url, httpPut);
   }
 
@@ -306,6 +317,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     HttpDelete httpDelete = new HttpDelete(url);
     httpDelete.addHeader(ACCEPT, APPLICATION_JSON);
     httpDelete.addHeader(CONTENT_TYPE, APPLICATION_JSON);
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpDelete.addHeader(WECHATPAY_SERIAL, serialNumber);
     return requestV3(url, httpDelete);
   }
 

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceApacheHttpImpl.java
@@ -44,6 +44,7 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
   private static final String ACCEPT = "Accept";
   private static final String CONTENT_TYPE = "Content-Type";
   private static final String APPLICATION_JSON = "application/json";
+  private static final String WECHATPAY_SERIAL = "Wechatpay-Serial";
 
   @Override
   public byte[] postForBytes(String url, String requestStr, boolean useKey) throws WxPayException {
@@ -101,7 +102,7 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     httpPost.addHeader(ACCEPT, APPLICATION_JSON);
     httpPost.addHeader(CONTENT_TYPE, APPLICATION_JSON);
     String serialNumber = getWechatpaySerial(getConfig());
-    httpPost.addHeader("Wechatpay-Serial", serialNumber);
+    httpPost.addHeader(WECHATPAY_SERIAL, serialNumber);
     try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
       //v3已经改为通过状态码判断200 204 成功
       int statusCode = response.getStatusLine().getStatusCode();
@@ -133,6 +134,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
   public String patchV3(String url, String requestStr) throws WxPayException {
     CloseableHttpClient httpClient = this.createApiV3HttpClient();
     HttpPatch httpPatch = new HttpPatch(url);
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpPatch.addHeader(WECHATPAY_SERIAL, serialNumber);
     httpPatch.setEntity(this.createEntry(requestStr));
 
     httpPatch.setConfig(RequestConfig.custom()
@@ -204,6 +207,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
 
   @Override
   public String postV3(String url, HttpPost httpPost) throws WxPayException {
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpPost.addHeader(WECHATPAY_SERIAL, serialNumber);
     return this.requestV3(url, httpPost);
   }
 
@@ -246,6 +251,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     HttpGet httpGet = new HttpGet(url);
     httpGet.addHeader(ACCEPT, APPLICATION_JSON);
     httpGet.addHeader(CONTENT_TYPE, APPLICATION_JSON);
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpGet.addHeader(WECHATPAY_SERIAL, serialNumber);
     return this.requestV3(url, httpGet);
   }
 
@@ -255,7 +262,7 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     httpGet.addHeader(ACCEPT, APPLICATION_JSON);
     httpGet.addHeader(CONTENT_TYPE, APPLICATION_JSON);
     String serialNumber = getWechatpaySerial(getConfig());
-    httpGet.addHeader("Wechatpay-Serial", serialNumber);
+    httpGet.addHeader(WECHATPAY_SERIAL, serialNumber);
     return this.requestV3(url, httpGet);
   }
 
@@ -264,6 +271,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     CloseableHttpClient httpClient = this.createApiV3HttpClient();
     HttpGet httpGet = new WxPayV3DownloadHttpGet(url);
     httpGet.addHeader(ACCEPT, ContentType.WILDCARD.getMimeType());
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpGet.addHeader(WECHATPAY_SERIAL, serialNumber);
     try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
       //v3已经改为通过状态码判断200 204 成功
       int statusCode = response.getStatusLine().getStatusCode();
@@ -295,6 +304,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     httpPut.setEntity(entity);
     httpPut.addHeader(ACCEPT, APPLICATION_JSON);
     httpPut.addHeader(CONTENT_TYPE, APPLICATION_JSON);
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpPut.addHeader(WECHATPAY_SERIAL, serialNumber);
     return requestV3(url, httpPut);
   }
 
@@ -303,6 +314,8 @@ public class WxPayServiceApacheHttpImpl extends BaseWxPayServiceImpl {
     HttpDelete httpDelete = new HttpDelete(url);
     httpDelete.addHeader(ACCEPT, APPLICATION_JSON);
     httpDelete.addHeader(CONTENT_TYPE, APPLICATION_JSON);
+    String serialNumber = getWechatpaySerial(getConfig());
+    httpDelete.addHeader(WECHATPAY_SERIAL, serialNumber);
     return requestV3(url, httpDelete);
   }
 


### PR DESCRIPTION
新增fullPublicKeyModel字段来控制，默认关闭，关闭时走老逻辑。开启时，只加载公钥所需相关配置，避免下载平台证书使灰度切换无法达到100%覆盖 #3573 