### PR TITLE
:art: #3624 【企业微信】企微微盘API接口不需要传userId

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveService.java
@@ -48,12 +48,11 @@ public interface WxCpOaWeDriveService {
    * 请求方式：POST（HTTPS）
    * 请求地址: <a href="https://qyapi.weixin.qq.com/cgi-bin/wedrive/space_dismiss?access_token=ACCESS_TOKEN">...</a>
    *
-   * @param userId  the user id
    * @param spaceId the space id
    * @return wx cp base resp
    * @throws WxErrorException the wx error exception
    */
-  WxCpBaseResp spaceDismiss(@NonNull String userId, @NonNull String spaceId) throws WxErrorException;
+  WxCpBaseResp spaceDismiss(@NonNull String spaceId) throws WxErrorException;
 
   /**
    * 获取空间信息
@@ -62,12 +61,11 @@ public interface WxCpOaWeDriveService {
    * 请求方式：POST（HTTPS）
    * 请求地址: <a href="https://qyapi.weixin.qq.com/cgi-bin/wedrive/space_info?access_token=ACCESS_TOKEN">...</a>
    *
-   * @param userId  the user id
    * @param spaceId the space id
    * @return wx cp space info
    * @throws WxErrorException the wx error exception
    */
-  WxCpSpaceInfo spaceInfo(@NonNull String userId, @NonNull String spaceId) throws WxErrorException;
+  WxCpSpaceInfo spaceInfo(@NonNull String spaceId) throws WxErrorException;
 
   /**
    * 添加成员/部门
@@ -115,12 +113,11 @@ public interface WxCpOaWeDriveService {
    * 请求方式：POST（HTTPS）
    * 请求地址: <a href="https://qyapi.weixin.qq.com/cgi-bin/wedrive/space_share?access_token=ACCESS_TOKEN">...</a>
    *
-   * @param userId  the user id
    * @param spaceId the space id
    * @return wx cp space share
    * @throws WxErrorException the wx error exception
    */
-  WxCpSpaceShare spaceShare(@NonNull String userId, @NonNull String spaceId) throws WxErrorException;
+  WxCpSpaceShare spaceShare(@NonNull String spaceId) throws WxErrorException;
 
   /**
    * 获取文件列表
@@ -155,18 +152,18 @@ public interface WxCpOaWeDriveService {
    * 请求方式：POST（HTTPS）
    * 请求地址: <a href="https://qyapi.weixin.qq.com/cgi-bin/wedrive/file_download?access_token=ACCESS_TOKEN">...</a>
    *
-   * @param fileId 文件fileid（只支持下载普通文件，不支持下载文件夹或微文档）
+   * @param fileId         文件fileid（只支持下载普通文件，不支持下载文件夹或微文档）
    * @param selectedTicket 微盘和文件选择器jsapi返回的selectedTicket。若填此参数，则不需要填fileid。
    * @return {
-   *     "errcode": 0,
-   *     "errmsg": "ok",
-   *     "download_url": "DOWNLOAD_URL",
-   *     "cookie_name": "COOKIE_NAME",
-   *     "cookie_value": "COOKIE_VALUE"
+   * "errcode": 0,
+   * "errmsg": "ok",
+   * "download_url": "DOWNLOAD_URL",
+   * "cookie_name": "COOKIE_NAME",
+   * "cookie_value": "COOKIE_VALUE"
    * }
    * @throws WxErrorException the wx error exception
    */
-  WxCpFileDownload fileDownload( String fileId, String selectedTicket) throws WxErrorException;
+  WxCpFileDownload fileDownload(String fileId, String selectedTicket) throws WxErrorException;
 
   /**
    * 重命名文件
@@ -271,14 +268,13 @@ public interface WxCpOaWeDriveService {
    * 请求方式：POST（HTTPS）
    * 请求地址: <a href="https://qyapi.weixin.qq.com/cgi-bin/wedrive/file_setting?access_token=ACCESS_TOKEN">...</a>
    *
-   * @param userId    the user id
    * @param fileId    the file id
    * @param authScope the auth scope
    * @param auth      the auth
    * @return wx cp base resp
    * @throws WxErrorException the wx error exception
    */
-  WxCpBaseResp fileSetting(@NonNull String userId, @NonNull String fileId, @NonNull Integer authScope, Integer auth) throws WxErrorException;
+  WxCpBaseResp fileSetting(@NonNull String fileId, @NonNull Integer authScope, Integer auth) throws WxErrorException;
 
   /**
    * 获取分享链接
@@ -287,11 +283,10 @@ public interface WxCpOaWeDriveService {
    * 请求方式：POST（HTTPS）
    * 请求地址: <a href="https://qyapi.weixin.qq.com/cgi-bin/wedrive/file_share?access_token=ACCESS_TOKEN">...</a>
    *
-   * @param userId the user id
    * @param fileId the file id
    * @return wx cp file share
    * @throws WxErrorException the wx error exception
    */
-  WxCpFileShare fileShare(@NonNull String userId, @NonNull String fileId) throws WxErrorException;
+  WxCpFileShare fileShare(@NonNull String fileId) throws WxErrorException;
 
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOaWeDriveServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOaWeDriveServiceImpl.java
@@ -39,20 +39,18 @@ public class WxCpOaWeDriveServiceImpl implements WxCpOaWeDriveService {
   }
 
   @Override
-  public WxCpBaseResp spaceDismiss(@NonNull String userId, @NonNull String spaceId) throws WxErrorException {
+  public WxCpBaseResp spaceDismiss(@NonNull String spaceId) throws WxErrorException {
     String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(SPACE_DISMISS);
     JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("userid", userId);
     jsonObject.addProperty("spaceid", spaceId);
     String responseContent = this.cpService.post(apiUrl, jsonObject.toString());
     return WxCpBaseResp.fromJson(responseContent);
   }
 
   @Override
-  public WxCpSpaceInfo spaceInfo(@NonNull String userId, @NonNull String spaceId) throws WxErrorException {
+  public WxCpSpaceInfo spaceInfo(@NonNull String spaceId) throws WxErrorException {
     String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(SPACE_INFO);
     JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("userid", userId);
     jsonObject.addProperty("spaceid", spaceId);
     String responseContent = this.cpService.post(apiUrl, jsonObject.toString());
     return WxCpSpaceInfo.fromJson(responseContent);
@@ -80,10 +78,9 @@ public class WxCpOaWeDriveServiceImpl implements WxCpOaWeDriveService {
   }
 
   @Override
-  public WxCpSpaceShare spaceShare(@NonNull String userId, @NonNull String spaceId) throws WxErrorException {
+  public WxCpSpaceShare spaceShare(@NonNull String spaceId) throws WxErrorException {
     String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(SPACE_SHARE);
     JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("userid", userId);
     jsonObject.addProperty("spaceid", spaceId);
     String responseContent = this.cpService.post(apiUrl, jsonObject.toString());
     return WxCpSpaceShare.fromJson(responseContent);
@@ -166,11 +163,9 @@ public class WxCpOaWeDriveServiceImpl implements WxCpOaWeDriveService {
   }
 
   @Override
-  public WxCpBaseResp fileSetting(@NonNull String userId, @NonNull String fileId, @NonNull Integer authScope,
-                                  Integer auth) throws WxErrorException {
+  public WxCpBaseResp fileSetting(@NonNull String fileId, @NonNull Integer authScope, Integer auth) throws WxErrorException {
     String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(FILE_SETTING);
     JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("userid", userId);
     jsonObject.addProperty("fileid", fileId);
     jsonObject.addProperty("auth_scope", authScope);
     if (auth != null) {
@@ -181,10 +176,9 @@ public class WxCpOaWeDriveServiceImpl implements WxCpOaWeDriveService {
   }
 
   @Override
-  public WxCpFileShare fileShare(@NonNull String userId, @NonNull String fileId) throws WxErrorException {
+  public WxCpFileShare fileShare(@NonNull String fileId) throws WxErrorException {
     String apiUrl = this.cpService.getWxCpConfigStorage().getApiUrl(FILE_SHARE);
     JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("userid", userId);
     jsonObject.addProperty("fileid", fileId);
     String responseContent = this.cpService.post(apiUrl, jsonObject.toString());
     return WxCpFileShare.fromJson(responseContent);

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveServiceTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/WxCpOaWeDriveServiceTest.java
@@ -59,13 +59,13 @@ public class WxCpOaWeDriveServiceTest {
     /*
      * 获取分享链接
      */
-    WxCpFileShare fileShare = cpService.getOaWeDriveService().fileShare(uId, fileId2);
+    WxCpFileShare fileShare = cpService.getOaWeDriveService().fileShare(fileId2);
     log.info("获取分享链接返回结果为：{}", fileShare.toJson());
 
     /*
      * 分享设置
      */
-    WxCpBaseResp fileSetting = cpService.getOaWeDriveService().fileSetting(uId, fileId2, 2, 1);
+    WxCpBaseResp fileSetting = cpService.getOaWeDriveService().fileSetting(fileId2, 2, 1);
     log.info("分享设置返回结果为：{}", fileSetting.toJson());
 
     /*
@@ -200,13 +200,13 @@ public class WxCpOaWeDriveServiceTest {
     /*
      * 获取邀请链接
      */
-    WxCpSpaceShare spaceShare = cpService.getOaWeDriveService().spaceShare(uId, spId);
+    WxCpSpaceShare spaceShare = cpService.getOaWeDriveService().spaceShare(spId);
     log.info("获取邀请链接信息为：{}", spaceShare.toJson());
 
     /*
      * 获取空间信息
      */
-    WxCpSpaceInfo data = cpService.getOaWeDriveService().spaceInfo(uId, spId);
+    WxCpSpaceInfo data = cpService.getOaWeDriveService().spaceInfo(spId);
     log.info("获取空间信息为：{}", data.toJson());
 
     /*
@@ -252,7 +252,7 @@ public class WxCpOaWeDriveServiceTest {
     /*
      * 获取空间信息
      */
-    WxCpSpaceInfo spaceInfo = cpService.getOaWeDriveService().spaceInfo("WangKai", "s.ww45d3e188865aca30.652091685u4h");
+    WxCpSpaceInfo spaceInfo = cpService.getOaWeDriveService().spaceInfo("s.ww45d3e188865aca30.652091685u4h");
     log.info("获取空间信息，spaceInfo信息为：{}", spaceInfo.toJson());
 
     /*
@@ -279,7 +279,7 @@ public class WxCpOaWeDriveServiceTest {
     /*
      * 解散空间
      */
-    WxCpBaseResp thisResp = cpService.getOaWeDriveService().spaceDismiss("WangKai", spaceCreateData.getSpaceId());
+    WxCpBaseResp thisResp = cpService.getOaWeDriveService().spaceDismiss(spaceCreateData.getSpaceId());
     log.info("解散成功：{}", thisResp.toJson());
 
   }


### PR DESCRIPTION
企业微信在2022年12月01号修改了企业微信微盘的API接口，取消接口中userId字段。