### PR TITLE
Add null check for textJsonElement in WxCpUserGsonAdapter

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/json/WxCpUserGsonAdapter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/json/WxCpUserGsonAdapter.java
@@ -128,7 +128,7 @@ public class WxCpUserGsonAdapter implements JsonDeserializer<WxCpUser>, JsonSeri
       switch (type) {
         case 0: {
           JsonElement textJsonElement = attrJsonElement.getAsJsonObject().get("text");
-          if (textJsonElement != null) {
+          if (textJsonElement != null && !textJsonElement.isJsonNull() && textJsonElement.isJsonObject()) {
             attr.setTextValue(GsonHelper.getString(textJsonElement.getAsJsonObject(), "value"));
           }
           break;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/json/WxCpUserGsonAdapter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/json/WxCpUserGsonAdapter.java
@@ -130,6 +130,8 @@ public class WxCpUserGsonAdapter implements JsonDeserializer<WxCpUser>, JsonSeri
           JsonElement textJsonElement = attrJsonElement.getAsJsonObject().get("text");
           if (textJsonElement != null && !textJsonElement.isJsonNull() && textJsonElement.isJsonObject()) {
             attr.setTextValue(GsonHelper.getString(textJsonElement.getAsJsonObject(), "value"));
+          } else {
+            attr.setTextValue(null); // Clear or set a default value to avoid stale data
           }
           break;
         }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/json/WxCpUserGsonAdapter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/util/json/WxCpUserGsonAdapter.java
@@ -127,8 +127,10 @@ public class WxCpUserGsonAdapter implements JsonDeserializer<WxCpUser>, JsonSeri
 
       switch (type) {
         case 0: {
-          attr.setTextValue(GsonHelper.getString(attrJsonElement.getAsJsonObject().get("text").getAsJsonObject(),
-            "value"));
+          JsonElement textJsonElement = attrJsonElement.getAsJsonObject().get("text");
+          if (textJsonElement != null) {
+            attr.setTextValue(GsonHelper.getString(textJsonElement.getAsJsonObject(), "value"));
+          }
           break;
         }
         case 1: {


### PR DESCRIPTION
For some Enterprise Wechat endpoints, `attrJsonElement.getAsJsonObject().get("text");` return null if there is no field `text` in `attrJsonElement`. We need to check null value before `getAsJsonObject`.