### PR TITLE
修复微信小程序多账号starter不支持设置数据格式的问题

### DIFF
--- a/spring-boot-starters/wx-java-miniapp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/configuration/services/AbstractWxMaConfiguration.java
+++ b/spring-boot-starters/wx-java-miniapp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/configuration/services/AbstractWxMaConfiguration.java
@@ -108,12 +108,12 @@ public abstract class AbstractWxMaConfiguration {
     return wxMaService;
   }
 
-  private void configApp(WxMaDefaultConfigImpl config, WxMaSingleProperties corpProperties) {
-    String appId = corpProperties.getAppId();
-    String appSecret = corpProperties.getAppSecret();
-    String token = corpProperties.getToken();
-    String aesKey = corpProperties.getAesKey();
-    boolean useStableAccessToken = corpProperties.isUseStableAccessToken();
+  private void configApp(WxMaDefaultConfigImpl config, WxMaSingleProperties properties) {
+    String appId = properties.getAppId();
+    String appSecret = properties.getAppSecret();
+    String token = properties.getToken();
+    String aesKey = properties.getAesKey();
+    boolean useStableAccessToken = properties.isUseStableAccessToken();
 
     config.setAppid(appId);
     config.setSecret(appSecret);
@@ -123,6 +123,7 @@ public abstract class AbstractWxMaConfiguration {
     if (StringUtils.isNotBlank(aesKey)) {
       config.setAesKey(aesKey);
     }
+    config.setMsgDataFormat(properties.getMsgDataFormat());
     config.useStableAccessToken(useStableAccessToken);
   }
 

--- a/spring-boot-starters/wx-java-miniapp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/properties/WxMaSingleProperties.java
+++ b/spring-boot-starters/wx-java-miniapp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/properties/WxMaSingleProperties.java
@@ -34,6 +34,11 @@ public class WxMaSingleProperties implements Serializable {
   private String aesKey;
 
   /**
+   * 消息格式，XML或者JSON.
+   */
+  private String msgDataFormat;
+
+  /**
    * 是否使用稳定版 Access Token
    */
   private boolean useStableAccessToken = false;


### PR DESCRIPTION
解决因微信小程序多账号starter不支持设置数据格式，导致消息解析出错的问题。