### PR TITLE
:bug: 【小程序】【公众号】修复了图片智能裁剪接口请求类型错误的问题

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaImgProcServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaImgProcServiceImpl.java
@@ -82,7 +82,7 @@ public class WxMaImgProcServiceImpl implements WxImgProcService {
       ratios = "";
     }
 
-    final String result = this.service.get(String.format(AI_CROP, imgUrl, ratios), null);
+    final String result = this.service.post(String.format(AI_CROP, imgUrl, ratios), "");
     return WxImgProcAiCropResult.fromJson(result);
   }
 

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpImgProcServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpImgProcServiceImpl.java
@@ -86,8 +86,8 @@ public class WxMpImgProcServiceImpl implements WxImgProcService {
       ratios = "";
     }
 
-    final String result = this.wxMpService.get(String.format(AI_CROP.getUrl(this.wxMpService.getWxMpConfigStorage()),
-      imgUrl, ratios), null);
+    final String result = this.wxMpService.post(String.format(AI_CROP.getUrl(this.wxMpService.getWxMpConfigStorage()),
+      imgUrl, ratios), "");
     return WxImgProcAiCropResult.fromJson(result);
   }
 

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/WxMpImgProcServiceImplTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/WxMpImgProcServiceImplTest.java
@@ -61,14 +61,14 @@ public class WxMpImgProcServiceImplTest {
 
   @Test
   public void testAiCrop() throws WxErrorException {
-    final WxImgProcAiCropResult result = this.mpService.getImgProcService().aiCrop("https://gitee.com/binary/weixin-java-tools/raw/master/images/qrcodes/mp.png");
+    final WxImgProcAiCropResult result = this.mpService.getImgProcService().aiCrop("https://gitee.com/binary/weixin-java-tools/images/banners/wiki.jpg");
     assertThat(result).isNotNull();
     System.out.println(result);
   }
 
   @Test
   public void testAiCrop2() throws WxErrorException {
-    final WxImgProcAiCropResult result = this.mpService.getImgProcService().aiCrop("https://gitee.com/binary/weixin-java-tools/raw/master/images/qrcodes/mp.png", "1,2.35");
+    final WxImgProcAiCropResult result = this.mpService.getImgProcService().aiCrop("https://gitee.com/binary/weixin-java-tools/images/banners/wiki.jpg", "1,2.35");
     assertThat(result).isNotNull();
     System.out.println(result);
   }


### PR DESCRIPTION
微信公众号官方文档中请求类型为post
([https://developers.weixin.qq.com/doc/subscription/api/openpoc/image/api_imgaicrop.html](https://developers.weixin.qq.com/doc/subscription/api/openpoc/image/api_imgaicrop.html))

当前版本代码中的请求类型为get,如下图:
<img width="1247" height="528" alt="image" src="https://github.com/user-attachments/assets/d17150bf-4708-4e52-9922-3092a6f5b3a6" />


