### PR TITLE
:art: #3694 #3433 小程序、支付、开放平台、微信视频号/微信小店 等 starter 中缺少对于微信基础地址的反向代理字段支持

### DIFF
--- a/spring-boot-starters/wx-java-channel-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/channel/configuration/services/AbstractWxChannelConfiguration.java
+++ b/spring-boot-starters/wx-java-channel-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/channel/configuration/services/AbstractWxChannelConfiguration.java
@@ -119,6 +119,8 @@ public abstract class AbstractWxChannelConfiguration {
       config.setAesKey(aesKey);
     }
     config.setStableAccessToken(useStableAccessToken);
+    config.setApiHostUrl(StringUtils.trimToNull(wxChannelSingleProperties.getApiHostUrl()));
+    config.setAccessTokenUrl(StringUtils.trimToNull(wxChannelSingleProperties.getAccessTokenUrl()));
   }
 
   private void configHttp(WxChannelDefaultConfigImpl config, WxChannelMultiProperties.ConfigStorage storage) {

--- a/spring-boot-starters/wx-java-channel-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/channel/properties/WxChannelSingleProperties.java
+++ b/spring-boot-starters/wx-java-channel-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/channel/properties/WxChannelSingleProperties.java
@@ -40,4 +40,16 @@ public class WxChannelSingleProperties implements Serializable {
    * 是否使用稳定版 Access Token
    */
   private boolean useStableAccessToken = false;
+
+  /**
+   * 自定义API主机地址，用于替换默认的 https://api.weixin.qq.com
+   * 例如：http://proxy.company.com:8080
+   */
+  private String apiHostUrl;
+
+  /**
+   * 自定义获取AccessToken地址，用于向自定义统一服务获取AccessToken
+   * 例如：http://proxy.company.com:8080/oauth/token
+   */
+  private String accessTokenUrl;
 }

--- a/spring-boot-starters/wx-java-channel-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/channel/config/storage/AbstractWxChannelConfigStorageConfiguration.java
+++ b/spring-boot-starters/wx-java-channel-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/channel/config/storage/AbstractWxChannelConfigStorageConfiguration.java
@@ -16,6 +16,8 @@ public abstract class AbstractWxChannelConfigStorageConfiguration {
     config.setAesKey(StringUtils.trimToNull(properties.getAesKey()));
     config.setMsgDataFormat(StringUtils.trimToNull(properties.getMsgDataFormat()));
     config.setStableAccessToken(properties.isUseStableAccessToken());
+    config.setApiHostUrl(StringUtils.trimToNull(properties.getApiHostUrl()));
+    config.setAccessTokenUrl(StringUtils.trimToNull(properties.getAccessTokenUrl()));
 
     WxChannelProperties.ConfigStorage configStorageProperties = properties.getConfigStorage();
     config.setHttpProxyHost(configStorageProperties.getHttpProxyHost());

--- a/spring-boot-starters/wx-java-channel-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/channel/properties/WxChannelProperties.java
+++ b/spring-boot-starters/wx-java-channel-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/channel/properties/WxChannelProperties.java
@@ -47,6 +47,18 @@ public class WxChannelProperties {
   private boolean useStableAccessToken = false;
 
   /**
+   * 自定义API主机地址，用于替换默认的 https://api.weixin.qq.com
+   * 例如：http://proxy.company.com:8080
+   */
+  private String apiHostUrl;
+
+  /**
+   * 自定义获取AccessToken地址，用于向自定义统一服务获取AccessToken
+   * 例如：http://proxy.company.com:8080/oauth/token
+   */
+  private String accessTokenUrl;
+
+  /**
    * 存储策略
    */
   private final ConfigStorage configStorage = new ConfigStorage();

--- a/spring-boot-starters/wx-java-cp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/cp/configuration/services/AbstractWxCpConfiguration.java
+++ b/spring-boot-starters/wx-java-cp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/cp/configuration/services/AbstractWxCpConfiguration.java
@@ -139,6 +139,9 @@ public abstract class AbstractWxCpConfiguration {
     if (StringUtils.isNotBlank(msgAuditLibPath)) {
       config.setMsgAuditLibPath(msgAuditLibPath);
     }
+    if (StringUtils.isNotBlank(wxCpSingleProperties.getBaseApiUrl())) {
+      config.setBaseApiUrl(wxCpSingleProperties.getBaseApiUrl());
+    }
   }
 
   private void configHttp(WxCpDefaultConfigImpl config, WxCpMultiProperties.ConfigStorage storage) {

--- a/spring-boot-starters/wx-java-cp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/cp/properties/WxCpSingleProperties.java
+++ b/spring-boot-starters/wx-java-cp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/cp/properties/WxCpSingleProperties.java
@@ -43,4 +43,10 @@ public class WxCpSingleProperties implements Serializable {
    * 微信企业号应用 会话存档类库路径
    */
   private String msgAuditLibPath;
+
+  /**
+   * 自定义企业微信服务器baseUrl，用于替换默认的 https://qyapi.weixin.qq.com
+   * 例如：http://proxy.company.com:8080
+   */
+  private String baseApiUrl;
 }

--- a/spring-boot-starters/wx-java-cp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/cp/properties/WxCpProperties.java
+++ b/spring-boot-starters/wx-java-cp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/cp/properties/WxCpProperties.java
@@ -49,6 +49,12 @@ public class WxCpProperties {
   private String msgAuditLibPath;
 
   /**
+   * 自定义企业微信服务器baseUrl，用于替换默认的 https://qyapi.weixin.qq.com
+   * 例如：http://proxy.company.com:8080
+   */
+  private String baseApiUrl;
+
+  /**
    * 配置存储策略，默认内存
    */
   private ConfigStorage configStorage = new ConfigStorage();

--- a/spring-boot-starters/wx-java-cp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/cp/storage/AbstractWxCpConfigStorageConfiguration.java
+++ b/spring-boot-starters/wx-java-cp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/cp/storage/AbstractWxCpConfigStorageConfiguration.java
@@ -37,6 +37,9 @@ public abstract class AbstractWxCpConfigStorageConfiguration {
     if (StringUtils.isNotBlank(msgAuditLibPath)) {
       config.setMsgAuditLibPath(msgAuditLibPath);
     }
+    if (StringUtils.isNotBlank(properties.getBaseApiUrl())) {
+      config.setBaseApiUrl(properties.getBaseApiUrl());
+    }
 
     WxCpProperties.ConfigStorage storage = properties.getConfigStorage();
     String httpProxyHost = storage.getHttpProxyHost();

--- a/spring-boot-starters/wx-java-miniapp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/configuration/services/AbstractWxMaConfiguration.java
+++ b/spring-boot-starters/wx-java-miniapp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/configuration/services/AbstractWxMaConfiguration.java
@@ -125,6 +125,8 @@ public abstract class AbstractWxMaConfiguration {
     }
     config.setMsgDataFormat(properties.getMsgDataFormat());
     config.useStableAccessToken(useStableAccessToken);
+    config.setApiHostUrl(StringUtils.trimToNull(properties.getApiHostUrl()));
+    config.setAccessTokenUrl(StringUtils.trimToNull(properties.getAccessTokenUrl()));
   }
 
   private void configHttp(WxMaDefaultConfigImpl config, WxMaMultiProperties.ConfigStorage storage) {

--- a/spring-boot-starters/wx-java-miniapp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/properties/WxMaSingleProperties.java
+++ b/spring-boot-starters/wx-java-miniapp-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/properties/WxMaSingleProperties.java
@@ -42,4 +42,16 @@ public class WxMaSingleProperties implements Serializable {
    * 是否使用稳定版 Access Token
    */
   private boolean useStableAccessToken = false;
+
+  /**
+   * 自定义API主机地址，用于替换默认的 https://api.weixin.qq.com
+   * 例如：http://proxy.company.com:8080
+   */
+  private String apiHostUrl;
+
+  /**
+   * 自定义获取AccessToken地址，用于向自定义统一服务获取AccessToken
+   * 例如：http://proxy.company.com:8080/oauth/token
+   */
+  private String accessTokenUrl;
 }

--- a/spring-boot-starters/wx-java-miniapp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/config/storage/AbstractWxMaConfigStorageConfiguration.java
+++ b/spring-boot-starters/wx-java-miniapp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/config/storage/AbstractWxMaConfigStorageConfiguration.java
@@ -19,6 +19,8 @@ public abstract class AbstractWxMaConfigStorageConfiguration {
     config.setAesKey(StringUtils.trimToNull(properties.getAesKey()));
     config.setMsgDataFormat(StringUtils.trimToNull(properties.getMsgDataFormat()));
     config.useStableAccessToken(properties.isUseStableAccessToken());
+    config.setApiHostUrl(StringUtils.trimToNull(properties.getApiHostUrl()));
+    config.setAccessTokenUrl(StringUtils.trimToNull(properties.getAccessTokenUrl()));
 
     WxMaProperties.ConfigStorage configStorageProperties = properties.getConfigStorage();
     config.setHttpProxyHost(configStorageProperties.getHttpProxyHost());

--- a/spring-boot-starters/wx-java-miniapp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/properties/WxMaProperties.java
+++ b/spring-boot-starters/wx-java-miniapp-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/miniapp/properties/WxMaProperties.java
@@ -50,6 +50,18 @@ public class WxMaProperties {
   private boolean useStableAccessToken = false;
 
   /**
+   * 自定义API主机地址，用于替换默认的 https://api.weixin.qq.com
+   * 例如：http://proxy.company.com:8080
+   */
+  private String apiHostUrl;
+
+  /**
+   * 自定义获取AccessToken地址，用于向自定义统一服务获取AccessToken
+   * 例如：http://proxy.company.com:8080/oauth/token
+   */
+  private String accessTokenUrl;
+
+  /**
    * 存储策略
    */
   private final ConfigStorage configStorage = new ConfigStorage();

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/AbstractWxOpenConfigStorageConfiguration.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/config/storage/AbstractWxOpenConfigStorageConfiguration.java
@@ -4,6 +4,7 @@ import com.binarywang.spring.starter.wxjava.open.properties.WxOpenProperties;
 import me.chanjar.weixin.common.util.http.apache.ApacheHttpClientBuilder;
 import me.chanjar.weixin.common.util.http.apache.DefaultApacheHttpClientBuilder;
 import me.chanjar.weixin.open.api.impl.WxOpenInMemoryConfigStorage;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author yl
@@ -30,6 +31,10 @@ public abstract class AbstractWxOpenConfigStorageConfiguration {
     }
     config.setRetrySleepMillis(retrySleepMillis);
     config.setMaxRetryTimes(maxRetryTimes);
+    
+    // 设置URL配置
+    config.setApiHostUrl(StringUtils.trimToNull(properties.getApiHostUrl()));
+    config.setAccessTokenUrl(StringUtils.trimToNull(properties.getAccessTokenUrl()));
     
     // 设置自定义的HttpClient超时配置
     ApacheHttpClientBuilder clientBuilder = config.getApacheHttpClientBuilder();

--- a/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/properties/WxOpenProperties.java
+++ b/spring-boot-starters/wx-java-open-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/open/properties/WxOpenProperties.java
@@ -41,6 +41,18 @@ public class WxOpenProperties {
   private String aesKey;
 
   /**
+   * 自定义API主机地址，用于替换默认的 https://api.weixin.qq.com
+   * 例如：http://proxy.company.com:8080
+   */
+  private String apiHostUrl;
+
+  /**
+   * 自定义获取AccessToken地址，用于向自定义统一服务获取AccessToken
+   * 例如：http://proxy.company.com:8080/oauth/token
+   */
+  private String accessTokenUrl;
+
+  /**
    * 存储策略.
    */
   private ConfigStorage configStorage = new ConfigStorage();

--- a/spring-boot-starters/wx-java-pay-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/config/WxPayAutoConfiguration.java
+++ b/spring-boot-starters/wx-java-pay-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/config/WxPayAutoConfiguration.java
@@ -50,15 +50,18 @@ public class WxPayAutoConfiguration {
     payConfig.setSubMchId(StringUtils.trimToNull(this.properties.getSubMchId()));
     payConfig.setKeyPath(StringUtils.trimToNull(this.properties.getKeyPath()));
     payConfig.setUseSandboxEnv(this.properties.isUseSandboxEnv());
+    payConfig.setNotifyUrl(StringUtils.trimToNull(this.properties.getNotifyUrl()));
     //以下是apiv3以及支付分相关
     payConfig.setServiceId(StringUtils.trimToNull(this.properties.getServiceId()));
     payConfig.setPayScoreNotifyUrl(StringUtils.trimToNull(this.properties.getPayScoreNotifyUrl()));
+    payConfig.setPayScorePermissionNotifyUrl(StringUtils.trimToNull(this.properties.getPayScorePermissionNotifyUrl()));
     payConfig.setPrivateKeyPath(StringUtils.trimToNull(this.properties.getPrivateKeyPath()));
     payConfig.setPrivateCertPath(StringUtils.trimToNull(this.properties.getPrivateCertPath()));
     payConfig.setCertSerialNo(StringUtils.trimToNull(this.properties.getCertSerialNo()));
     payConfig.setApiV3Key(StringUtils.trimToNull(this.properties.getApiv3Key()));
     payConfig.setPublicKeyId(StringUtils.trimToNull(this.properties.getPublicKeyId()));
     payConfig.setPublicKeyPath(StringUtils.trimToNull(this.properties.getPublicKeyPath()));
+    payConfig.setApiHostUrl(StringUtils.trimToNull(this.properties.getApiHostUrl()));
 
     wxPayService.setConfig(payConfig);
     return wxPayService;

--- a/spring-boot-starters/wx-java-pay-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/properties/WxPayProperties.java
+++ b/spring-boot-starters/wx-java-pay-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/properties/WxPayProperties.java
@@ -60,9 +60,19 @@ public class WxPayProperties {
   private String apiv3Key;
 
   /**
+   * 微信支付异步回调地址，通知url必须为直接可访问的url，不能携带参数
+   */
+  private String notifyUrl;
+
+  /**
    * 微信支付分回调地址
    */
   private String payScoreNotifyUrl;
+
+  /**
+   * 微信支付分授权回调地址
+   */
+  private String payScorePermissionNotifyUrl;
 
   /**
    * apiv3 商户apiclient_key.pem
@@ -89,5 +99,11 @@ public class WxPayProperties {
    * 默认不使用
    */
   private boolean useSandboxEnv;
+
+  /**
+   * 自定义API主机地址，用于替换默认的 https://api.mch.weixin.qq.com
+   * 例如：http://proxy.company.com:8080
+   */
+  private String apiHostUrl;
 
 }

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenInMemoryConfigStorage.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenInMemoryConfigStorage.java
@@ -65,6 +65,16 @@ public class WxOpenInMemoryConfigStorage implements WxOpenConfigStorage {
    */
   private int maxRetryTimes = 5;
 
+  /**
+   * 自定义API主机地址，用于替换默认的 https://api.weixin.qq.com
+   */
+  private String apiHostUrl;
+
+  /**
+   * 自定义获取AccessToken地址，用于向自定义统一服务获取AccessToken
+   */
+  private String accessTokenUrl;
+
   private ApacheHttpClientBuilder apacheHttpClientBuilder;
 
   private Map<String, Token> authorizerRefreshTokens = new ConcurrentHashMap<>();
@@ -290,6 +300,13 @@ public class WxOpenInMemoryConfigStorage implements WxOpenConfigStorage {
       this.accessTokenLock = wxOpenConfigStorage.getLockByKey(appId + ":accessTokenLock");
       this.jsapiTicketLock = wxOpenConfigStorage.getLockByKey(appId + ":jsapiTicketLock");
       this.cardApiTicketLock = wxOpenConfigStorage.getLockByKey(appId + ":cardApiTicketLock");
+      
+      // 自动获取外层配置的URL设置
+      if (wxOpenConfigStorage instanceof WxOpenInMemoryConfigStorage) {
+        WxOpenInMemoryConfigStorage parentConfig = (WxOpenInMemoryConfigStorage) wxOpenConfigStorage;
+        this.apiHostUrl = parentConfig.getApiHostUrl();
+        this.accessTokenUrl = parentConfig.getAccessTokenUrl();
+      }
     }
 
     @Override
@@ -636,6 +653,26 @@ public class WxOpenInMemoryConfigStorage implements WxOpenConfigStorage {
     @Override
     public void setHostConfig(WxMpHostConfig hostConfig) {
       this.hostConfig = hostConfig;
+    }
+
+    @Override
+    public String getApiHostUrl() {
+      return this.apiHostUrl;
+    }
+
+    @Override
+    public void setApiHostUrl(String apiHostUrl) {
+      this.apiHostUrl = apiHostUrl;
+    }
+
+    @Override
+    public String getAccessTokenUrl() {
+      return this.accessTokenUrl;
+    }
+
+    @Override
+    public void setAccessTokenUrl(String accessTokenUrl) {
+      this.accessTokenUrl = accessTokenUrl;
     }
   }
 }

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -54,7 +54,7 @@ public class WxPayConfig {
   /**
    * 微信支付接口请求地址域名部分.
    */
-  private String payBaseUrl = DEFAULT_PAY_BASE_URL;
+  private String apiHostUrl = DEFAULT_PAY_BASE_URL;
 
   /**
    * http请求连接超时时间.
@@ -194,28 +194,28 @@ public class WxPayConfig {
 
 
   private CloseableHttpClient apiV3HttpClient;
-  
+
   /**
    * 用于普通支付接口的可复用HttpClient，使用连接池
    */
   private CloseableHttpClient httpClient;
-  
+
   /**
    * 用于需要SSL证书的支付接口的可复用HttpClient，使用连接池
    */
   private CloseableHttpClient sslHttpClient;
-  
+
   /**
    * 支持扩展httpClientBuilder
    */
   private HttpClientBuilderCustomizer httpClientBuilderCustomizer;
   private HttpClientBuilderCustomizer apiV3HttpClientBuilderCustomizer;
-  
+
   /**
    * HTTP连接池最大连接数，默认20
    */
   private int maxConnTotal = 20;
-  
+
   /**
    * HTTP连接池每个路由的最大连接数，默认10
    */
@@ -272,12 +272,12 @@ public class WxPayConfig {
    *
    * @return 微信支付接口请求地址域名
    */
-  public String getPayBaseUrl() {
-    if (StringUtils.isEmpty(this.payBaseUrl)) {
+  public String getApiHostUrl() {
+    if (StringUtils.isEmpty(this.apiHostUrl)) {
       return DEFAULT_PAY_BASE_URL;
     }
 
-    return this.payBaseUrl;
+    return this.apiHostUrl;
   }
 
   @SneakyThrows
@@ -375,7 +375,7 @@ public class WxPayConfig {
       } else {
         certificatesVerifier = VerifierBuilder.build(
           this.getCertSerialNo(), this.getMchId(), this.getApiV3Key(), merchantPrivateKey, wxPayHttpProxy,
-          this.getCertAutoUpdateTime(), this.getPayBaseUrl(), this.getPublicKeyId(), publicKey);
+          this.getCertAutoUpdateTime(), this.getApiHostUrl(), this.getPublicKeyId(), publicKey);
       }
 
       WxPayV3HttpClientBuilder wxPayV3HttpClientBuilder = WxPayV3HttpClientBuilder.create()
@@ -531,7 +531,7 @@ public class WxPayConfig {
 
   /**
    * 初始化使用连接池的HttpClient
-   * 
+   *
    * @return CloseableHttpClient
    * @throws WxPayException 初始化异常
    */
@@ -539,31 +539,31 @@ public class WxPayConfig {
     if (this.httpClient != null) {
       return this.httpClient;
     }
-    
+
     // 创建连接池管理器
     PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
     connectionManager.setMaxTotal(this.maxConnTotal);
     connectionManager.setDefaultMaxPerRoute(this.maxConnPerRoute);
-    
+
     // 创建HttpClient构建器
     org.apache.http.impl.client.HttpClientBuilder httpClientBuilder = HttpClients.custom()
         .setConnectionManager(connectionManager);
-        
+
     // 配置代理
     configureProxy(httpClientBuilder);
-    
+
     // 提供自定义httpClientBuilder的能力
     Optional.ofNullable(httpClientBuilderCustomizer).ifPresent(e -> {
       e.customize(httpClientBuilder);
     });
-    
+
     this.httpClient = httpClientBuilder.build();
     return this.httpClient;
   }
 
   /**
    * 初始化使用连接池且支持SSL的HttpClient
-   * 
+   *
    * @return CloseableHttpClient
    * @throws WxPayException 初始化异常
    */
@@ -571,31 +571,31 @@ public class WxPayConfig {
     if (this.sslHttpClient != null) {
       return this.sslHttpClient;
     }
-    
+
     // 初始化SSL上下文
     SSLContext sslContext = this.getSslContext();
     if (null == sslContext) {
       sslContext = this.initSSLContext();
     }
-    
+
     // 创建支持SSL的连接池管理器
     PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
     connectionManager.setMaxTotal(this.maxConnTotal);
     connectionManager.setDefaultMaxPerRoute(this.maxConnPerRoute);
-    
+
     // 创建HttpClient构建器，配置SSL
     org.apache.http.impl.client.HttpClientBuilder httpClientBuilder = HttpClients.custom()
         .setConnectionManager(connectionManager)
         .setSSLSocketFactory(new SSLConnectionSocketFactory(sslContext, new DefaultHostnameVerifier()));
-        
+
     // 配置代理
     configureProxy(httpClientBuilder);
-    
+
     // 提供自定义httpClientBuilder的能力
     Optional.ofNullable(httpClientBuilderCustomizer).ifPresent(e -> {
       e.customize(httpClientBuilder);
     });
-    
+
     this.sslHttpClient = httpClientBuilder.build();
     return this.sslHttpClient;
   }
@@ -620,7 +620,7 @@ public class WxPayConfig {
 
   /**
    * 获取用于普通支付接口的HttpClient
-   * 
+   *
    * @return CloseableHttpClient
    */
   public CloseableHttpClient getHttpClient() {
@@ -629,7 +629,7 @@ public class WxPayConfig {
 
   /**
    * 获取用于SSL支付接口的HttpClient
-   * 
+   *
    * @return CloseableHttpClient
    */
   public CloseableHttpClient getSslHttpClient() {

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
@@ -217,9 +217,9 @@ public abstract class BaseWxPayServiceImpl implements WxPayService {
       if (StringUtils.isNotBlank(this.getConfig().getApiV3Key())) {
         throw new WxRuntimeException("微信支付V3 目前不支持沙箱模式！");
       }
-      return this.getConfig().getPayBaseUrl() + "/xdc/apiv2sandbox";
+      return this.getConfig().getApiHostUrl() + "/xdc/apiv2sandbox";
     }
-    return this.getConfig().getPayBaseUrl();
+    return this.getConfig().getApiHostUrl();
   }
 
   @Override

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImplTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImplTest.java
@@ -936,7 +936,7 @@ public class BaseWxPayServiceImplTest {
       WxPayOrderQueryV3Request request = new WxPayOrderQueryV3Request();
       request.setOutTradeNo("n1ZvYqjAg3D3LUBa");
       WxPayConfig config = this.payService.getConfig();
-      config.setPayBaseUrl("http://api.mch.weixin.qq.com");
+      config.setApiHostUrl("http://api.mch.weixin.qq.com");
       config.setHttpProxyHost("12.11.1.113");
       config.setHttpProxyPort(8015);
       WxPayOrderQueryV3Result result = this.payService.queryOrderV3(request);


### PR DESCRIPTION
对 #3433 #3694  进行合并提交

支持对于 小程序、支付、开放平台、微信视频号/微信小店 等starter 对于微信基础地址进行反向代理配置，便于内网部署使用。

ps: 本次更改不涉及公众号和企点 ，其 starter 已支持该配置

# WxJava 各模块 URL 字段配置表
  | 模块     | 核心字段                          | Starter字段                       | 默认值                           | 说明              |
  |---------|----------------------------------|----------------------------------|-------------------------------|-----------------|
  | MP      | apiHost                          | hosts.apiHost                    | https://api.weixin.qq.com     | 公众号 API 域名      |
  | MP      | mpHost                           | hosts.mpHost                     | https://mp.weixin.qq.com      | 公众号管理域名         |
  | MP      | openHost                         | hosts.openHost                   | https://open.weixin.qq.com    | 开放平台域名          |
  | Miniapp | apiHostUrl                       | apiHostUrl                       | https://api.weixin.qq.com     | 小程序 API 域名      |
  | Miniapp | accessTokenUrl                   | accessTokenUrl                   | -                             | 自定义 Token 获取地址  |
  | Pay     | apiHostUrl (统一)                 | apiHostUrl (统一)                 | https://api.mch.weixin.qq.com | 支付 API 域名 (已统一) |
  | Pay     | notifyUrl (新增)                  | notifyUrl (新增)                  | -                             | 支付异步回调地址 (新增)   |
  | Pay     | payScoreNotifyUrl                | payScoreNotifyUrl                | -                             | 支付分回调地址         |
  | Pay     | payScorePermissionNotifyUrl (新增) | payScorePermissionNotifyUrl (新增) | -                             | 支付分授权回调地址 (新增)  |
  | CP      | baseApiUrl                       | baseApiUrl                       | https://qyapi.weixin.qq.com   | 企业微信 API 域名     |
  | Channel | apiHostUrl                       | apiHostUrl                       | https://api.weixin.qq.com     | 视频号 API 域名      |
  | Channel | accessTokenUrl                   | accessTokenUrl                   | -                             | 自定义 Token 获取地址  |
  | Open    | apiHostUrl                       | apiHostUrl                       | https://api.weixin.qq.com     | 开放平台 API 域名     |
  | Open    | accessTokenUrl                   | accessTokenUrl                   | -                             | 自定义 Token 获取地址  |
  | Qidian  | apiHost (MP)                     | hosts.apiHost                    | https://api.weixin.qq.com     | 企点 API 域名       |
  | Qidian  | openHost                         | hosts.openHost                   | https://open.weixin.qq.com    | 企点开放平台域名        |
  | Qidian  | qidianHost                       | hosts.qidianHost                 | https://api.qidian.qq.com     | 企点专用 API 域名     |



```java
# 单实例配置示例
  wx:
    mp:
      hosts:
        api-host: http://proxy.company.com:8080
        mp-host: http://mp-proxy.company.com:8080

    miniapp:
      api-host-url: http://proxy.company.com:8080
      access-token-url: http://token-service.company.com/miniapp/token

    pay:
      api-host-url: http://pay-proxy.company.com:8080

    cp:
      base-api-url: http://cp-proxy.company.com:8080

    channel:
      api-host-url: http://proxy.company.com:8080
      access-token-url: http://token-service.company.com/channel/token

    open:
      api-host-url: http://proxy.company.com:8080
      access-token-url: http://token-service.company.com/open/token

  # 多实例配置示例
  wx:
    miniapp:
      apps:
        tenant1:
          api-host-url: http://tenant1-proxy.company.com:8080
          access-token-url: http://token-service.company.com/tenant1/token
```
