### PR TITLE
企业微信API回调验签错误 #3756

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/crypto/WxCryptUtil.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/crypto/WxCryptUtil.java
@@ -350,7 +350,11 @@ public class WxCryptUtil {
       xmlContent = new String(Arrays.copyOfRange(bytes, startIndex, endIndex), CHARSET);
       fromAppid = new String(Arrays.copyOfRange(bytes, endIndex, bytes.length), CHARSET);
     } catch (Exception e) {
-      throw new WxRuntimeException(e);
+      if (e instanceof WxRuntimeException) {
+        throw (WxRuntimeException) e;
+      } else {
+        throw new WxRuntimeException(e);
+      }
     }
 
     // appid不相同的情况 暂时忽略这段判断

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/crypto/WxCryptUtil.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/crypto/WxCryptUtil.java
@@ -333,12 +333,22 @@ public class WxCryptUtil {
       byte[] bytes = PKCS7Encoder.decode(original);
 
       // 分离16位随机字符串,网络字节序和AppId
+      if (bytes == null || bytes.length < 20) {
+        throw new WxRuntimeException("解密后数据长度异常，可能为错误的密文或EncodingAESKey");
+      }
       byte[] networkOrder = Arrays.copyOfRange(bytes, 16, 20);
 
       int xmlLength = bytesNetworkOrder2Number(networkOrder);
 
-      xmlContent = new String(Arrays.copyOfRange(bytes, 20, 20 + xmlLength), CHARSET);
-      fromAppid = new String(Arrays.copyOfRange(bytes, 20 + xmlLength, bytes.length), CHARSET);
+      // 长度边界校验，避免非法长度导致的越界/参数异常
+      int startIndex = 20;
+      int endIndex = startIndex + xmlLength;
+      if (xmlLength < 0 || endIndex > bytes.length) {
+        throw new WxRuntimeException("解密后数据格式非法：消息长度不正确，可能为错误的密文或EncodingAESKey");
+      }
+
+      xmlContent = new String(Arrays.copyOfRange(bytes, startIndex, endIndex), CHARSET);
+      fromAppid = new String(Arrays.copyOfRange(bytes, endIndex, bytes.length), CHARSET);
     } catch (Exception e) {
       throw new WxRuntimeException(e);
     }


### PR DESCRIPTION
我找到了 WxCryptUtil.decrypt 函数，并对其进行了加固，通过在切片之前验证解密后的有效载荷长度，避免了 Arrays.copyOfRange 的 IllegalArgumentException 异常。如果数据格式错误（通常是由于 EncodingAESKey 错误或密文损坏），现在会抛出一个清晰的 WxRuntimeException 异常，而不是像之前那样抛出“20 > …”的错误。

构建和测试：

重新构建项目并重试回调验证；现在你应该会得到解密成功的结果，或者一个清晰、可操作的错误信息，而不是 IllegalArgumentException 异常。
我在 WxCryptUtil.decrypt 函数中添加了强大的长度检查，以防止运行时崩溃，并在密钥/密文错误时提供精确的错误消息。

如果仍然遇到“签名校验失败”或新的“数据格式非法”错误：

请确保以下三项完全匹配：token、时间戳、nonce 和确切的 Encrypt 值。
请验证您的 EncodingAESKey 是否适用于您的应用：
WeCom 自建应用：使用 corpId
第三方套件：使用 suiteId
请确保您根据不同的场景传递正确的 receiveid，并且传递的 token/EncodingAESKey 与 WeCom 控制台中配置的 token/EncodingAESKey 一致。