### PR TITLE
bugfix: 如果RedisTemplate指定KeySerializer，可能会导致加锁成功，无法解锁

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/locks/RedisTemplateSimpleDistributedLock.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/locks/RedisTemplateSimpleDistributedLock.java
@@ -93,9 +93,11 @@ public class RedisTemplateSimpleDistributedLock implements Lock {
   @Override
   public void unlock() {
     if (valueThreadLocal.get() != null) {
-      // 提示: 必须指定returnType, 类型: 此处必须为Long, 不能是Integer
-      RedisScript<Long> script = new DefaultRedisScript<>("if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end", Long.class);
-      redisTemplate.execute(script, Collections.singletonList(key), valueThreadLocal.get());
+      redisTemplate.executePipelined((RedisCallback<String>) connection -> {
+          connection.eval("if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end".getBytes(),
+                          ReturnType.INTEGER, 1, key.getBytes(), valueThreadLocal.get().getBytes());
+          return null;
+      });
       valueThreadLocal.remove();
     }
   }


### PR DESCRIPTION
当redisTemplate指定keySerializer，且keySerializer中会对redis key添加自定义前缀时，RedisStringCommands#get/set方法会忽略keySerializer，而StringRedisTemplate#execute不会忽略keySerializer，所以会导致加锁成功，而解锁失败（由于redis key不一样）